### PR TITLE
Resource pool sessions handling regression with login state

### DIFF
--- a/close_test.go
+++ b/close_test.go
@@ -32,7 +32,9 @@ func TestClose(t *testing.T) {
 	// Verify that close and re-open works.
 	var err error
 	var key *PKCS11PrivateKeyDSA
-	ConfigureFromFile("config")
+	if _, err := ConfigureFromFile("config"); err != nil {
+		t.Fatal(err)
+	}
 	psize := dsa.L1024N160
 	if key, err = GenerateDSAKeyPair(dsaSizes[psize]); err != nil {
 		t.Errorf("crypto11.GenerateDSAKeyPair: %v", err)
@@ -47,15 +49,21 @@ func TestClose(t *testing.T) {
 		t.Errorf("crypto11.dsa.PKCS11PrivateKeyDSA.Identify: %v", err)
 		return
 	}
-	Close()
+	if err = Close(); err != nil {
+		t.Fatal(err)
+	}
 	for i := 0; i < 5; i++ {
-		ConfigureFromFile("config")
+		if _, err := ConfigureFromFile("config"); err != nil {
+			t.Fatal(err)
+		}
 		var key2 crypto.PrivateKey
 		if key2, err = FindKeyPair(id, nil); err != nil {
 			t.Errorf("crypto11.dsa.FindDSAKeyPair by id: %v", err)
 			return
 		}
 		testDsaSigning(t, key2.(*PKCS11PrivateKeyDSA), psize, fmt.Sprintf("close%d", i))
-		Close()
+		if err = Close(); err != nil {
+			t.Fatal(err)
+		}
 	}
 }

--- a/common.go
+++ b/common.go
@@ -79,10 +79,10 @@ func dsaGeneric(slot uint, key pkcs11.ObjectHandle, mechanism uint, digest []byt
 	var sig dsaSignature
 	mech := []*pkcs11.Mechanism{pkcs11.NewMechanism(mechanism, nil)}
 	err = withSession(slot, func(session *PKCS11Session) error {
-		if err = libHandle.SignInit(session.Handle, mech, key); err != nil {
+		if err = instance.ctx.SignInit(session.Handle, mech, key); err != nil {
 			return err
 		}
-		sigBytes, err = libHandle.Sign(session.Handle, digest)
+		sigBytes, err = instance.ctx.Sign(session.Handle, digest)
 		return err
 	})
 	if err != nil {

--- a/crypto11.go
+++ b/crypto11.go
@@ -251,16 +251,6 @@ func Configure(config *PKCS11Config) (*pkcs11.Ctx, error) {
 		return nil, err
 	}
 
-	if instance.token.Flags&pkcs11.CKF_LOGIN_REQUIRED != 0 {
-		if err = withSession(instance.slot, func(session *PKCS11Session) error {
-			// login is pkcs11 context wide, not just handle/session scoped
-			return session.Ctx.Login(session.Handle, pkcs11.CKU_USER, config.Pin)
-		}); err != nil {
-			log.Printf("Failed to open PKCS#11 Session: %s", err.Error())
-			return nil, err
-		}
-	}
-
 	return instance.ctx, nil
 }
 

--- a/crypto11_test.go
+++ b/crypto11_test.go
@@ -85,9 +85,9 @@ func TestLoginContext(t *testing.T) {
 	})
 
 	t.Run("key identity with expiration", func(t *testing.T) {
-		prevIdleTimeout := instance.idleTimeout
-		defer func() {instance.idleTimeout = prevIdleTimeout}()
-		instance.idleTimeout = time.Second
+		prevIdleTimeout := instance.cfg.IdleTimeout
+		defer func() {instance.cfg.IdleTimeout = prevIdleTimeout}()
+		instance.cfg.IdleTimeout = time.Second
 
 		configureWithPin(t)
 		defer Close()
@@ -111,8 +111,8 @@ func TestLoginContext(t *testing.T) {
 			return
 		}
 
-		// kick out all idle sessions
-		time.Sleep(instance.idleTimeout + time.Second)
+		// kick out all cfg.Idle sessions
+		time.Sleep(instance.cfg.IdleTimeout + time.Second)
 
 		var key2 crypto.PrivateKey
 		if key2, err = FindKeyPair(id, nil); err != nil {
@@ -163,9 +163,9 @@ func TestLoginContext(t *testing.T) {
 }
 
 func TestIdentityExpiration(t *testing.T) {
-	prevIdleTimeout := instance.idleTimeout
-	defer func() {instance.idleTimeout = prevIdleTimeout}()
-	instance.idleTimeout = time.Second
+	prevIdleTimeout := instance.cfg.IdleTimeout
+	defer func() {instance.cfg.IdleTimeout = prevIdleTimeout}()
+	instance.cfg.IdleTimeout = time.Second
 
 	configureWithPin(t)
 	defer Close()
@@ -183,8 +183,8 @@ func TestIdentityExpiration(t *testing.T) {
 		return
 	}
 
-	// kick out all idle sessions
-	time.Sleep(instance.idleTimeout + time.Second)
+	// kick out all cfg.Idle sessions
+	time.Sleep(instance.cfg.IdleTimeout + time.Second)
 
 	if _, _, err = key.Identify(); err != nil {
 		if perr, ok := err.(pkcs11.Error); !ok || perr != pkcs11.CKR_OBJECT_HANDLE_INVALID {

--- a/crypto11_test.go
+++ b/crypto11_test.go
@@ -22,7 +22,15 @@
 package crypto11
 
 import (
+	"crypto"
+	"crypto/dsa"
+	"encoding/json"
+	"fmt"
+	"github.com/miekg/pkcs11"
+	"log"
+	"os"
 	"testing"
+	"time"
 )
 
 func TestInitializeFromConfig(t *testing.T) {
@@ -35,3 +43,123 @@ func TestInitializeFromConfig(t *testing.T) {
 	ConfigureFromFile("config")
 	Close()
 }
+
+func TestLoginContext(t *testing.T) {
+	t.Run("key identity with login", func(t *testing.T) {
+		configureWithPin(t)
+		defer Close()
+
+		// Generate a key and and close a session
+		var err error
+		var key *PKCS11PrivateKeyDSA
+		psize := dsa.L1024N160
+		if key, err = GenerateDSAKeyPair(dsaSizes[psize]); err != nil {
+			t.Errorf("crypto11.GenerateDSAKeyPair: %v", err)
+			return
+		}
+		if key == nil {
+			t.Errorf("crypto11.dsa.GenerateDSAKeyPair: returned nil but no error")
+			return
+		}
+
+		var id []byte
+		if id, _, err = key.Identify(); err != nil {
+			t.Errorf("crypto11.dsa.PKCS11PrivateKeyDSA.Identify: %v", err)
+			return
+		}
+		if err = Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		// Reopen a session and try to find a key.
+		// Valid session must enlist a key.
+		// If login is not performed than it will fail.
+		configureWithPin(t)
+
+		var key2 crypto.PrivateKey
+		if key2, err = FindKeyPair(id, nil); err != nil {
+			t.Errorf("crypto11.dsa.FindDSAKeyPair by id: %v", err)
+			return
+		}
+		testDsaSigning(t, key2.(*PKCS11PrivateKeyDSA), psize, fmt.Sprintf("close%d", 0))
+	})
+
+	t.Run("key identity with expiration", func(t *testing.T) {
+		prevIdleTimeout := instance.idleTimeout
+		defer func() {instance.idleTimeout = prevIdleTimeout}()
+		instance.idleTimeout = time.Second
+
+		configureWithPin(t)
+		defer Close()
+
+		// Generate a key and and close a session
+		var err error
+		var key *PKCS11PrivateKeyDSA
+		psize := dsa.L1024N160
+		if key, err = GenerateDSAKeyPair(dsaSizes[psize]); err != nil {
+			t.Errorf("crypto11.GenerateDSAKeyPair: %v", err)
+			return
+		}
+		if key == nil {
+			t.Errorf("crypto11.dsa.GenerateDSAKeyPair: returned nil but no error")
+			return
+		}
+
+		var id []byte
+		if id, _, err = key.Identify(); err != nil {
+			t.Errorf("crypto11.dsa.PKCS11PrivateKeyDSA.Identify: %v", err)
+			return
+		}
+
+		// kick out all idle sessions
+		time.Sleep(instance.idleTimeout + time.Second)
+
+		// Reopen a session and try to find a key.
+		// Valid session must enlist a key.
+		// If login is not performed than it will fail.
+		configureWithPin(t)
+
+		var key2 crypto.PrivateKey
+		if key2, err = FindKeyPair(id, nil); err != nil {
+			t.Errorf("crypto11.dsa.FindDSAKeyPair by id: %v", err)
+			return
+		}
+		testDsaSigning(t, key2.(*PKCS11PrivateKeyDSA), psize, fmt.Sprintf("close%d", 0))
+	})
+}
+
+func configureWithPin(t *testing.T) (*pkcs11.Ctx, error) {
+	cfg, err := getConfig("config")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Pin == "" {
+		t.Fatal("invalid configuration. configuration must have PIN non empty.")
+	}
+
+	ctx, err := Configure(cfg)
+	if err != nil {
+		t.Fatal("failed to configure service:", err)
+	}
+
+	return ctx, nil
+}
+
+func getConfig(configLocation string) (*PKCS11Config, error) {
+	file, err := os.Open(configLocation)
+	if err != nil {
+		log.Printf("Could not open config file: %s", configLocation)
+		return nil, err
+	}
+	defer file.Close()
+	configDecoder := json.NewDecoder(file)
+	config := &PKCS11Config{}
+	err = configDecoder.Decode(config)
+	if err != nil {
+		log.Printf("Could decode config file: %s", err.Error())
+		return nil, err
+	}
+	return config, nil
+}
+

--- a/crypto11_test.go
+++ b/crypto11_test.go
@@ -114,11 +114,6 @@ func TestLoginContext(t *testing.T) {
 		// kick out all idle sessions
 		time.Sleep(instance.idleTimeout + time.Second)
 
-		// Reopen a session and try to find a key.
-		// Valid session must enlist a key.
-		// If login is not performed than it will fail.
-		configureWithPin(t)
-
 		var key2 crypto.PrivateKey
 		if key2, err = FindKeyPair(id, nil); err != nil {
 			t.Errorf("crypto11.dsa.FindDSAKeyPair by id: %v", err)

--- a/dsa.go
+++ b/dsa.go
@@ -67,7 +67,7 @@ func exportDSAPublicKey(session *PKCS11Session, pubHandle pkcs11.ObjectHandle) (
 //
 // The key will have a random label and ID.
 func GenerateDSAKeyPair(params *dsa.Parameters) (*PKCS11PrivateKeyDSA, error) {
-	return GenerateDSAKeyPairOnSlot(defaultSlot, nil, nil, params)
+	return GenerateDSAKeyPairOnSlot(instance.slot, nil, nil, params)
 }
 
 // GenerateDSAKeyPairOnSlot creates a DSA private key on a specified slot
@@ -76,7 +76,7 @@ func GenerateDSAKeyPair(params *dsa.Parameters) (*PKCS11PrivateKeyDSA, error) {
 func GenerateDSAKeyPairOnSlot(slot uint, id []byte, label []byte, params *dsa.Parameters) (*PKCS11PrivateKeyDSA, error) {
 	var k *PKCS11PrivateKeyDSA
 	var err error
-	if err = ensureSessions(libHandle, slot); err != nil {
+	if err = ensureSessions(instance, slot); err != nil {
 		return nil, err
 	}
 	err = withSession(slot, func(session *PKCS11Session) error {

--- a/ecdsa.go
+++ b/ecdsa.go
@@ -222,7 +222,7 @@ func exportECDSAPublicKey(session *PKCS11Session, pubHandle pkcs11.ObjectHandle)
 // Only a limited set of named elliptic curves are supported. The
 // underlying PKCS#11 implementation may impose further restrictions.
 func GenerateECDSAKeyPair(c elliptic.Curve) (*PKCS11PrivateKeyECDSA, error) {
-	return GenerateECDSAKeyPairOnSlot(defaultSlot, nil, nil, c)
+	return GenerateECDSAKeyPairOnSlot(instance.slot, nil, nil, c)
 }
 
 // GenerateECDSAKeyPairOnSlot creates an ECDSA private key using curve c, on a specified slot.
@@ -234,7 +234,7 @@ func GenerateECDSAKeyPair(c elliptic.Curve) (*PKCS11PrivateKeyECDSA, error) {
 func GenerateECDSAKeyPairOnSlot(slot uint, id []byte, label []byte, c elliptic.Curve) (*PKCS11PrivateKeyECDSA, error) {
 	var k *PKCS11PrivateKeyECDSA
 	var err error
-	if err = ensureSessions(libHandle, slot); err != nil {
+	if err = ensureSessions(instance, slot); err != nil {
 		return nil, err
 	}
 	err = withSession(slot, func(session *PKCS11Session) error {

--- a/keys.go
+++ b/keys.go
@@ -36,7 +36,7 @@ func (object *PKCS11Object) Identify() (id []byte, label []byte, err error) {
 		pkcs11.NewAttribute(pkcs11.CKA_LABEL, nil),
 	}
 	if err = withSession(object.Slot, func(session *PKCS11Session) error {
-		a, err = libHandle.GetAttributeValue(session.Handle, object.Handle, a)
+		a, err = instance.ctx.GetAttributeValue(session.Handle, object.Handle, a)
 		return err
 	}); err != nil {
 		return nil, nil, err
@@ -79,7 +79,7 @@ func findKey(session *PKCS11Session, id []byte, label []byte, keyclass uint, key
 //
 // Either (but not both) of id and label may be nil, in which case they are ignored.
 func FindKeyPair(id []byte, label []byte) (crypto.PrivateKey, error) {
-	return FindKeyPairOnSlot(defaultSlot, id, label)
+	return FindKeyPairOnSlot(instance.slot, id, label)
 }
 
 // FindKeyPairOnSlot retrieves a previously created asymmetric key, using a specified slot.
@@ -88,7 +88,7 @@ func FindKeyPair(id []byte, label []byte) (crypto.PrivateKey, error) {
 func FindKeyPairOnSlot(slot uint, id []byte, label []byte) (crypto.PrivateKey, error) {
 	var err error
 	var k crypto.PrivateKey
-	if err = ensureSessions(libHandle, slot); err != nil {
+	if err = ensureSessions(instance, slot); err != nil {
 		return nil, err
 	}
 	err = withSession(slot, func(session *PKCS11Session) error {

--- a/pool_test.go
+++ b/pool_test.go
@@ -35,6 +35,10 @@ import (
 
 func TestPoolTimeout(t *testing.T) {
 	t.Run("first login", func(t *testing.T) {
+		prevIdleTimeout := idleTimeout
+		defer func() {idleTimeout = prevIdleTimeout}()
+		idleTimeout = time.Second
+
 		cfg, err := getConfig("config")
 		if err != nil {
 			t.Fatal(err)
@@ -63,6 +67,10 @@ func TestPoolTimeout(t *testing.T) {
 	})
 
 	t.Run("reuse expired handle", func(t *testing.T) {
+		prevIdleTimeout := idleTimeout
+		defer func() {idleTimeout = prevIdleTimeout}()
+		idleTimeout = time.Second
+
 		cfg, err := getConfig("config")
 		if err != nil {
 			t.Fatal(err)
@@ -94,9 +102,6 @@ func TestPoolTimeout(t *testing.T) {
 			}
 		}
 	})
-
-	// TODO: make timeout configurable. timeouts configuration must stick to the pool instance.
-	// TODO: reduce idle timeout in test with the help of configuration.
 }
 
 func getConfig(configLocation string) (*PKCS11Config, error) {

--- a/pool_test.go
+++ b/pool_test.go
@@ -1,0 +1,81 @@
+// Copyright 2018 Thales e-Security, Inc
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package crypto11
+
+import (
+	"crypto/elliptic"
+	"encoding/json"
+	"github.com/miekg/pkcs11"
+	"log"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestPoolTimeout(t *testing.T) {
+	cfg, err := getConfig("config")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Pin == "" {
+		t.Fatal("invalid configuration. configuration must have PIN non empty.")
+	}
+
+	_, err = Configure(cfg)
+	if err != nil {
+		t.Fatal("failed to configure service:", err)
+	}
+
+	time.Sleep(idleTimeout + 2*time.Second)
+
+	_, err = GenerateECDSAKeyPair(elliptic.P256())
+	if err != nil {
+		if perr, ok := err.(pkcs11.Error); ok && perr == pkcs11.CKR_USER_NOT_LOGGED_IN {
+			t.Fatal("pool handle session incorrectly, login required but missing:", err)
+		} else {
+			t.Fatal("failed to generate a key, unexpected error:", err)
+		}
+	}
+
+	// TODO: check handling of handles from previous sessions with pkcs11: 0x82: CKR_OBJECT_HANDLE_INVALID
+	// TODO: make timeout configurable. timeouts configuration must stick to the pool instance.
+	// TODO: reduce idle timeout in test with the help of configuration.
+}
+
+func getConfig(configLocation string) (*PKCS11Config, error) {
+	file, err := os.Open(configLocation)
+	if err != nil {
+		log.Printf("Could not open config file: %s", configLocation)
+		return nil, err
+	}
+	defer file.Close()
+	configDecoder := json.NewDecoder(file)
+	config := &PKCS11Config{}
+	err = configDecoder.Decode(config)
+	if err != nil {
+		log.Printf("Could decode config file: %s", err.Error())
+		return nil, err
+	}
+	return config, nil
+}
+

--- a/rand.go
+++ b/rand.go
@@ -30,11 +30,11 @@ type PKCS11RandReader struct {
 // This implements the Reader interface for PKCS11RandReader.
 func (reader PKCS11RandReader) Read(data []byte) (n int, err error) {
 	var result []byte
-	if libHandle == nil {
+	if instance.ctx == nil {
 		return 0, ErrNotConfigured
 	}
-	if err = withSession(defaultSlot, func(session *PKCS11Session) error {
-		result, err = libHandle.GenerateRandom(session.Handle, len(data))
+	if err = withSession(instance.slot, func(session *PKCS11Session) error {
+		result, err = instance.ctx.GenerateRandom(session.Handle, len(data))
 		return err
 	}); err != nil {
 		return 0, err

--- a/rsa.go
+++ b/rsa.go
@@ -92,7 +92,7 @@ func exportRSAPublicKey(session *PKCS11Session, pubHandle pkcs11.ObjectHandle) (
 // RSA private keys are generated with both sign and decrypt
 // permissions, and a public exponent of 65537.
 func GenerateRSAKeyPair(bits int) (*PKCS11PrivateKeyRSA, error) {
-	return GenerateRSAKeyPairOnSlot(defaultSlot, nil, nil, bits)
+	return GenerateRSAKeyPairOnSlot(instance.slot, nil, nil, bits)
 }
 
 // GenerateRSAKeyPairOnSlot creates a RSA private key on a specified slot
@@ -101,7 +101,7 @@ func GenerateRSAKeyPair(bits int) (*PKCS11PrivateKeyRSA, error) {
 func GenerateRSAKeyPairOnSlot(slot uint, id []byte, label []byte, bits int) (*PKCS11PrivateKeyRSA, error) {
 	var k *PKCS11PrivateKeyRSA
 	var err error
-	if err = ensureSessions(libHandle, slot); err != nil {
+	if err = ensureSessions(instance, slot); err != nil {
 		return nil, err
 	}
 	err = withSession(slot, func(session *PKCS11Session) error {

--- a/rsa_test.go
+++ b/rsa_test.go
@@ -240,7 +240,7 @@ func testRsaEncryptionOAEP(t *testing.T, key crypto.Decrypter, hashFunction cryp
 	needMechanism(t, slot, pkcs11.CKM_RSA_PKCS_OAEP)
 	// Doesn't seem to be a way to query supported MGFs so we do that the hard way.
 	var info pkcs11.Info
-	if info, err = libHandle.GetInfo(); err != nil {
+	if info, err = instance.ctx.GetInfo(); err != nil {
 		t.Errorf("GetInfo: %v", err)
 		return
 	}
@@ -275,7 +275,7 @@ func needMechanism(t *testing.T, slot uint, wantMech uint) {
 	if slot == ^uint(0) { // not using PKCS#11
 		return
 	}
-	if mechs, err = libHandle.GetMechanismList(slot); err != nil {
+	if mechs, err = instance.ctx.GetMechanismList(slot); err != nil {
 		t.Errorf("GetMechanismList: %v", err)
 		return
 	}

--- a/sessions.go
+++ b/sessions.go
@@ -171,9 +171,7 @@ func loginToken(s *PKCS11Session) error {
 	// login is pkcs11 context wide, not just handle/session scoped
 	err := s.Ctx.Login(s.Handle, pkcs11.CKU_USER, instance.cfg.Pin)
 	if err != nil {
-		if code, ok := err.(pkcs11.Error); ok && (
-			code == pkcs11.CKR_USER_ANOTHER_ALREADY_LOGGED_IN ||
-				code == pkcs11.CKR_USER_ALREADY_LOGGED_IN) {
+		if code, ok := err.(pkcs11.Error); ok && code == pkcs11.CKR_USER_ALREADY_LOGGED_IN {
 			return nil
 		} else {
 			log.Printf("Failed to open PKCS#11 Session: %s", err.Error())


### PR DESCRIPTION
### Abstract

Resource pool handles sessions which require a login procedure wrong.

### Issue: https://github.com/ThalesIgnite/crypto11/issues/9

### Description

If it is easy to fix logging issue for new sessions in the pool, I am not sure it will be easy to do anything for rancid handles.

One of the consequences of using resource pool with expiration is that users handles got rancid when related session got kicked out of the pool, and thus it becomes impossible to store any handles kinds cross the requests boundaries for loaded services. Another way of handling it could be to force them to implement some routine of handling this specific error `CKR_OBJECT_HANDLE_INVALID`. From the point of view of this change caused by an introduction of RP https://github.com/ThalesIgnite/crypto11/pull/3 backward compatibility is broken.

### Mitigation plan

- test which reproduces regressions (handling of `pkcs11: 0x101: CKR_USER_NOT_LOGGED_IN`).
- check handling of handles from previous sessions with `pkcs11: 0x82: CKR_OBJECT_HANDLE_INVALID`.
- make idle timeout configurable, reduce idle timeout in test.
- fix sessions handling

### Backward compatibility

- IdleTimeout exposed to the configuration
- IdleTimeout is 0 by default
- NewSessionTimeout is 0 by default and replaced with the PoolTimeout to the configuration
