### PR TITLE
Avoid trampling on existing errors in defer funcs

### DIFF
--- a/crypto11.go
+++ b/crypto11.go
@@ -292,7 +292,10 @@ func ConfigureFromFile(configLocation string) (ctx *pkcs11.Ctx, err error) {
 		return nil, err
 	}
 	defer func() {
-		err = file.Close()
+		closeErr := file.Close()
+		if closeErr != nil && err == nil {
+			err = closeErr
+		}
 	}()
 
 	configDecoder := json.NewDecoder(file)

--- a/crypto11.go
+++ b/crypto11.go
@@ -293,7 +293,7 @@ func ConfigureFromFile(configLocation string) (ctx *pkcs11.Ctx, err error) {
 	}
 	defer func() {
 		closeErr := file.Close()
-		if closeErr != nil && err == nil {
+		if err == nil {
 			err = closeErr
 		}
 	}()

--- a/keys.go
+++ b/keys.go
@@ -66,7 +66,7 @@ func findKey(session *PKCS11Session, id []byte, label []byte, keyclass uint, key
 	}
 	defer func() {
 		finalErr := session.Ctx.FindObjectsFinal(session.Handle)
-		if finalErr != nil && err == nil {
+		if err == nil {
 			err = finalErr
 		}
 	}()

--- a/keys.go
+++ b/keys.go
@@ -65,7 +65,10 @@ func findKey(session *PKCS11Session, id []byte, label []byte, keyclass uint, key
 		return 0, err
 	}
 	defer func() {
-		err = session.Ctx.FindObjectsFinal(session.Handle)
+		finalErr := session.Ctx.FindObjectsFinal(session.Handle)
+		if finalErr != nil && err == nil {
+			err = finalErr
+		}
 	}()
 	if handles, _, err = session.Ctx.FindObjects(session.Handle, 1); err != nil {
 		return 0, err


### PR DESCRIPTION
My fix for #24 introduced a bug, which this commit resolves. The problem was  overwriting error information with the results from deferred functions, without first checking if an error had already been reported. 

This could have the consequence of hiding errors entirely. Or, at least, replacing useful errors with less useful ones.

Thanks to @optnfast for spotting.