### PR TITLE
Generate 64 character hexadecimal labels

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -1,0 +1,20 @@
+package crypto11
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestGenerateKeyLabel(t *testing.T) {
+	_, err := ConfigureFromFile("config")
+	require.NoError(t, err)
+
+	for i :=0; i < 100; i++ {
+		label, err := generateKeyLabel()
+		require.NoError(t, err)
+		require.Len(t, label, labelLength)
+		for _, b := range label {
+			require.NotEqual(t, byte(0), b)
+		}
+	}
+}


### PR DESCRIPTION
This fix prevents nil bytes from appearing in automatically generated labels. I opted to keep 64 character labels, as that appears to be the original intent.

Instead of base64-encoding the label, the result is simply 64 ASCII bytes containing hexadecimal characters.

Fixes #31.