### PR TITLE
Add support for ...WithAttributes functions

### DIFF
--- a/attributes.go
+++ b/attributes.go
@@ -1,0 +1,187 @@
+package crypto11
+
+import "github.com/miekg/pkcs11"
+
+type AttributeType uint
+
+//noinspection GoUnusedConst
+const (
+	CkaClass                  = AttributeType(0x00000000)
+	CkaToken                  = AttributeType(0x00000001)
+	CkaPrivate                = AttributeType(0x00000002)
+	CkaLabel                  = AttributeType(0x00000003)
+	CkaApplication            = AttributeType(0x00000010)
+	CkaValue                  = AttributeType(0x00000011)
+	CkaObjectId               = AttributeType(0x00000012)
+	CkaCertificateType        = AttributeType(0x00000080)
+	CkaIssuer                 = AttributeType(0x00000081)
+	CkaSerialNumber           = AttributeType(0x00000082)
+	CkaAcIssuer               = AttributeType(0x00000083)
+	CkaOwner                  = AttributeType(0x00000084)
+	CkaAttrTypes              = AttributeType(0x00000085)
+	CkaTrusted                = AttributeType(0x00000086)
+	CkaCertificateCategory    = AttributeType(0x00000087)
+	CkaJavaMidpSecurityDomain = AttributeType(0x00000088)
+	CkaUrl                    = AttributeType(0x00000089)
+	CkaHashOfSubjectPublicKey = AttributeType(0x0000008A)
+	CkaHashOfIssuerPublicKey  = AttributeType(0x0000008B)
+	CkaNameHashAlgorithm      = AttributeType(0x0000008C)
+	CkaCheckValue             = AttributeType(0x00000090)
+
+	CkaKeyType         = AttributeType(0x00000100)
+	CkaSubject         = AttributeType(0x00000101)
+	CkaId              = AttributeType(0x00000102)
+	CkaSensitive       = AttributeType(0x00000103)
+	CkaEncrypt         = AttributeType(0x00000104)
+	CkaDecrypt         = AttributeType(0x00000105)
+	CkaWrap            = AttributeType(0x00000106)
+	CkaUnwrap          = AttributeType(0x00000107)
+	CkaSign            = AttributeType(0x00000108)
+	CkaSignRecover     = AttributeType(0x00000109)
+	CkaVerify          = AttributeType(0x0000010A)
+	CkaVerifyRecover   = AttributeType(0x0000010B)
+	CkaDerive          = AttributeType(0x0000010C)
+	CkaStartDate       = AttributeType(0x00000110)
+	CkaEndDate         = AttributeType(0x00000111)
+	CkaModus           = AttributeType(0x00000120)
+	CkaModusBits       = AttributeType(0x00000121)
+	CkaPublicExponent  = AttributeType(0x00000122)
+	CkaPrivateExponent = AttributeType(0x00000123)
+	CkaPrime1          = AttributeType(0x00000124)
+	CkaPrime2          = AttributeType(0x00000125)
+	CkaExponent1       = AttributeType(0x00000126)
+	CkaExponent2       = AttributeType(0x00000127)
+	CkaCoefficient     = AttributeType(0x00000128)
+	CkaPublicKeyInfo   = AttributeType(0x00000129)
+	CkaPrime           = AttributeType(0x00000130)
+	CkaSubprime        = AttributeType(0x00000131)
+	CkaBase            = AttributeType(0x00000132)
+
+	CkaPrimeBits    = AttributeType(0x00000133)
+	CkaSubprimeBits = AttributeType(0x00000134)
+	/* (To retain backwards-compatibility) */
+	CkaSubPrimeBits = CkaSubprimeBits
+
+	CkaValueBits        = AttributeType(0x00000160)
+	CkaValueLen         = AttributeType(0x00000161)
+	CkaExtractable      = AttributeType(0x00000162)
+	CkaLocal            = AttributeType(0x00000163)
+	CkaNeverExtractable = AttributeType(0x00000164)
+	CkaAlwaysSensitive  = AttributeType(0x00000165)
+	CkaKeyGenMechanism  = AttributeType(0x00000166)
+
+	CkaModifiable = AttributeType(0x00000170)
+	CkaCopyable   = AttributeType(0x00000171)
+
+	/* new for v2.40 */
+	CkaDestroyable = AttributeType(0x00000172)
+
+	/* CKA_ECDSA_PARAMS is deprecated in v2.11,
+	 * CKA_EC_PARAMS is preferred. */
+	CkaEcdsaParams = AttributeType(0x00000180)
+	CkaEcParams    = AttributeType(0x00000180)
+
+	CkaEcPoint = AttributeType(0x00000181)
+
+	/* CKA_SECONDARY_AUTH, CKA_AUTH_PIN_FLAGS,
+	 * are new for v2.10. Deprecated in v2.11 and onwards. */
+	CkaSecondaryAuth = AttributeType(0x00000200) /* Deprecated */
+	CkaAuthPinFlags  = AttributeType(0x00000201) /* Deprecated */
+
+	CkaAlwaysAuthenticate = AttributeType(0x00000202)
+
+	CkaWrapWithTrusted = AttributeType(0x00000210)
+
+	ckfArrayAttribute = AttributeType(0x40000000)
+
+	CkaWrapTemplate   = AttributeType(ckfArrayAttribute | AttributeType(0x00000211))
+	CkaUnwrapTemplate = AttributeType(ckfArrayAttribute | AttributeType(0x00000212))
+
+	CkaOtpFormat               = AttributeType(0x00000220)
+	CkaOtpLength               = AttributeType(0x00000221)
+	CkaOtpTimeInterval         = AttributeType(0x00000222)
+	CkaOtpUserFriendlyMode     = AttributeType(0x00000223)
+	CkaOtpChallengeRequirement = AttributeType(0x00000224)
+	CkaOtpTimeRequirement      = AttributeType(0x00000225)
+	CkaOtpCounterRequirement   = AttributeType(0x00000226)
+	CkaOtpPinRequirement       = AttributeType(0x00000227)
+	CkaOtpCounter              = AttributeType(0x0000022E)
+	CkaOtpTime                 = AttributeType(0x0000022F)
+	CkaOtpUserIdentifier       = AttributeType(0x0000022A)
+	CkaOtpServiceIdentifier    = AttributeType(0x0000022B)
+	CkaOtpServiceLogo          = AttributeType(0x0000022C)
+	CkaOtpServiceLogoType      = AttributeType(0x0000022D)
+
+	CkaGostr3410Params = AttributeType(0x00000250)
+	CkaGostr3411Params = AttributeType(0x00000251)
+	CkaGost28147Params = AttributeType(0x00000252)
+
+	CkaHwFeatureType = AttributeType(0x00000300)
+	CkaResetOnInit   = AttributeType(0x00000301)
+	CkaHasReset      = AttributeType(0x00000302)
+
+	CkaPixelX                 = AttributeType(0x00000400)
+	CkaPixelY                 = AttributeType(0x00000401)
+	CkaResolution             = AttributeType(0x00000402)
+	CkaCharRows               = AttributeType(0x00000403)
+	CkaCharColumns            = AttributeType(0x00000404)
+	CkaColor                  = AttributeType(0x00000405)
+	CkaBitsPerPixel           = AttributeType(0x00000406)
+	CkaCharSets               = AttributeType(0x00000480)
+	CkaEncodingMethods        = AttributeType(0x00000481)
+	CkaMimeTypes              = AttributeType(0x00000482)
+	CkaMechanismType          = AttributeType(0x00000500)
+	CkaRequiredCmsAttributes  = AttributeType(0x00000501)
+	CkaDefatCmsAttributes     = AttributeType(0x00000502)
+	CkaSupportedCmsAttributes = AttributeType(0x00000503)
+	CkaAllowedMechanisms      = AttributeType(ckfArrayAttribute | AttributeType(0x00000600))
+)
+
+// An Attribute represents a PKCS#11 CK_ATTRIBUTE type.
+type Attribute struct {
+	Type  AttributeType
+	Value []byte
+}
+
+// NewAttribute is a helper function that populates a new Attribute for common data types. This function will
+// panic if value is not of type bool, int, uint, string, []byte or time.Time (or is nil).
+func NewAttribute(attributeType AttributeType, value interface{}) *Attribute {
+	// Use pkcs11 helper.
+	pAttr := pkcs11.NewAttribute(uint(attributeType), value)
+	return &Attribute{
+		Type:  attributeType,
+		Value: pAttr.Value,
+	}
+}
+
+// mergeAttributes combines a template with additional attributes. Where conflicts occur, the latest definition
+// wins.
+func mergeAttributes(template []*pkcs11.Attribute, additional []*Attribute) []*pkcs11.Attribute {
+	attributes := make(map[uint]*pkcs11.Attribute)
+
+	for _, a := range template {
+		attributes[a.Type] = a
+	}
+
+	for _, a := range additional {
+		attributes[uint(a.Type)] = &pkcs11.Attribute{Value: a.Value, Type: uint(a.Type)}
+	}
+
+	var result []*pkcs11.Attribute
+	for _, v := range attributes {
+		result = append(result, v)
+	}
+	return result
+}
+
+func wrapAttributes(template []*pkcs11.Attribute) []*Attribute {
+	var result []*Attribute
+	for _, v := range template {
+		result = append(result, &Attribute{
+			Type:  AttributeType(v.Type),
+			Value: v.Value,
+		})
+	}
+
+	return result
+}

--- a/attributes.go
+++ b/attributes.go
@@ -171,48 +171,44 @@ func CopyAttribute(a *Attribute) *Attribute {
 	}
 }
 
-// An AttributeSet groups together operations that are common for a slice of Attributes
-type AttributeSet struct {
-	Attributes map[AttributeType]*Attribute
-}
+// An AttributeSet groups together operations that are common for a collection of Attributes
+type AttributeSet map[AttributeType]*Attribute
 
-func NewAttributeSet() *AttributeSet {
-	return &AttributeSet{
-		Attributes: map[AttributeType]*Attribute{},
-	}
+func NewAttributeSet() AttributeSet {
+	return make(AttributeSet)
 }
 
 // Add creates a new Attribute and adds it to the AttributeSet. This function will return an error if value is
 // not of type bool, int, uint, string, []byte or time.Time (or is nil).
-func (a *AttributeSet) Add(attributeType AttributeType, value interface{}) (*AttributeSet, error) {
+func (a AttributeSet) Add(attributeType AttributeType, value interface{}) (AttributeSet, error) {
 	attr, err := NewAttribute(attributeType, value)
 	if err != nil {
-		return &AttributeSet{}, err
+		return nil, err
 	}
-	a.Attributes[attributeType] = attr
+	a[attributeType] = attr
 	return a, nil
 }
 
 // Set adds the attribute to the AttributeSet overwriting the preexisting entry
-func (a *AttributeSet) Set(attribute *Attribute) *AttributeSet {
-	a.Attributes[attribute.Type] = attribute
+func (a AttributeSet) Set(attribute *Attribute) AttributeSet {
+	a[attribute.Type] = attribute
 	return a
 }
 
 // Merge 
-func (a *AttributeSet) Merge(additional *AttributeSet) *AttributeSet {
-	for _, attribute := range additional.Attributes {
-		a.Attributes[attribute.Type] = attribute
+func (a AttributeSet) Merge(additional AttributeSet) AttributeSet {
+	for _, attribute := range additional {
+		a[attribute.Type] = attribute
 	}
 	return a
 }
 
 // AddIfNotPresent adds the attribute if the Attribute Type is not already present in the AttributeSet
-func (a *AttributeSet) AddIfNotPresent(additional []*Attribute) *AttributeSet {
+func (a AttributeSet) AddIfNotPresent(additional []*Attribute) AttributeSet {
 	for _, additionalAttr := range additional {
 		// Only add the attribute if it is not already present in the Attribute map
-		if _, ok := a.Attributes[additionalAttr.Type]; !ok {
-			a.Attributes[additionalAttr.Type] = additionalAttr
+		if _, ok := a[additionalAttr.Type]; !ok {
+			a[additionalAttr.Type] = additionalAttr
 		}
 	}
 	return a
@@ -220,9 +216,9 @@ func (a *AttributeSet) AddIfNotPresent(additional []*Attribute) *AttributeSet {
 
 // ToSlice returns a slice of Attributes contained in the AttributeSet. This will return a deep copy
 // of the Attributes in the AttributeSet.
-func (a *AttributeSet) ToSlice() []*Attribute {
+func (a AttributeSet) ToSlice() []*Attribute {
 	var attributes []*Attribute
-	for _, v := range a.Attributes {
+	for _, v := range a {
 		duplicateAttr := CopyAttribute(v)
 		attributes = append(attributes, duplicateAttr)
 	}
@@ -231,17 +227,17 @@ func (a *AttributeSet) ToSlice() []*Attribute {
 
 // Copy returns a deep copy of the AttributeSet. This function will return an error if value is not of type 
 // bool, int, uint, string, []byte or time.Time (or is nil).
-func (a *AttributeSet) Copy() (*AttributeSet, error) {
+func (a AttributeSet) Copy() AttributeSet {
 	b := NewAttributeSet()
-	for _, v := range a.Attributes {
-		b.Attributes[v.Type] = CopyAttribute(v)
+	for _, v := range a {
+		b[v.Type] = CopyAttribute(v)
 	}
-	return b, nil
+	return b
 }
 
 // NewAttributeSetWithId is a helper function that populates a new slice of Attributes with the provided ID.
 // This function returns an error if the ID is an empty slice.
-func NewAttributeSetWithId(id []byte) (*AttributeSet, error) {
+func NewAttributeSetWithId(id []byte) (AttributeSet, error) {
 	if err := notNilBytes(id, "id"); err != nil {
 		return nil, err
 	}
@@ -250,7 +246,7 @@ func NewAttributeSetWithId(id []byte) (*AttributeSet, error) {
 
 // NewAttributeSetWithIDAndLabel is a helper function that populates a new slice of Attributes with the
 // provided ID and Label. This function returns an error if either the ID or the Label is an empty slice.
-func NewAttributeSetWithIDAndLabel(id, label []byte) (a *AttributeSet, err error) {
+func NewAttributeSetWithIDAndLabel(id, label []byte) (a AttributeSet, err error) {
 	if a, err = NewAttributeSetWithId(id); err != nil {
 		return nil, err
 	}

--- a/dsa.go
+++ b/dsa.go
@@ -83,8 +83,8 @@ func (c *Context) GenerateDSAKeyPair(id []byte, params *dsa.Parameters) (Signer,
 	if err != nil {
 		return nil, err
 	}
-	// Copy the AttributeSet to allow modifications. Ignoring any errors as they will be caught above
-	private, _ := public.Copy()
+	// Copy the AttributeSet to allow modifications.
+	private := public.Copy()
 
 	return c.GenerateDSAKeyPairWithAttributes(public, private, params)
 }
@@ -100,15 +100,15 @@ func (c *Context) GenerateDSAKeyPairWithLabel(id, label []byte, params *dsa.Para
 	if err != nil {
 		return nil, err
 	}
-	// Copy the AttributeSet to allow modifications. Ignoring any errors as they will be caught above
-	private, _ := public.Copy()
+	// Copy the AttributeSet to allow modifications.
+	private := public.Copy()
 
 	return c.GenerateDSAKeyPairWithAttributes(public, private, params)
 }
 
 // GenerateDSAKeyPairWithAttributes creates a DSA key pair on the token. Required Attributes that are missing
 // in the provided "public" and "private" AttributeSets will be set to a default value.
-func (c *Context) GenerateDSAKeyPairWithAttributes(public, private *AttributeSet, params *dsa.Parameters) (k Signer, err error) {
+func (c *Context) GenerateDSAKeyPairWithAttributes(public, private AttributeSet, params *dsa.Parameters) (k Signer, err error) {
 	if c.closed.Get() {
 		return nil, errClosed
 	}

--- a/dsa.go
+++ b/dsa.go
@@ -79,11 +79,14 @@ func (c *Context) GenerateDSAKeyPair(id []byte, params *dsa.Parameters) (Signer,
 		return nil, errClosed
 	}
 
-	template, err := NewAttributeSetWithId(id)
+	public, err := NewAttributeSetWithId(id)
 	if err != nil {
 		return nil, err
 	}
-	return c.GenerateDSAKeyPairWithAttributes(template, template.Copy(), params)
+	// Copy the AttributeSet to allow modifications. Ignoring any errors as they will be caught above
+	private, _ := public.Copy()
+
+	return c.GenerateDSAKeyPairWithAttributes(public, private, params)
 }
 
 // GenerateDSAKeyPairWithLabel creates a DSA key pair on the token. The id and label parameters are used to
@@ -93,11 +96,14 @@ func (c *Context) GenerateDSAKeyPairWithLabel(id, label []byte, params *dsa.Para
 		return nil, errClosed
 	}
 
-	template, err := NewAttributeSetWithIDAndLabel(id, label)
+	public, err := NewAttributeSetWithIDAndLabel(id, label)
 	if err != nil {
 		return nil, err
 	}
-	return c.GenerateDSAKeyPairWithAttributes(template, template.Copy(), params)
+	// Copy the AttributeSet to allow modifications. Ignoring any errors as they will be caught above
+	private, _ := public.Copy()
+
+	return c.GenerateDSAKeyPairWithAttributes(public, private, params)
 }
 
 // GenerateDSAKeyPairWithAttributes creates a DSA key pair on the token. Required Attributes that are missing

--- a/ecdsa.go
+++ b/ecdsa.go
@@ -210,8 +210,8 @@ func (c *Context) GenerateECDSAKeyPair(id []byte, curve elliptic.Curve) (Signer,
 	if err != nil {
 		return nil, err
 	}
-	// Copy the AttributeSet to allow modifications. Ignoring any errors as they will be caught above
-	private, _ := public.Copy()
+	// Copy the AttributeSet to allow modifications.
+	private := public.Copy()
 
 	return c.GenerateECDSAKeyPairWithAttributes(public, private, curve)
 }
@@ -228,15 +228,15 @@ func (c *Context) GenerateECDSAKeyPairWithLabel(id, label []byte, curve elliptic
 	if err != nil {
 		return nil, err
 	}
-	// Copy the AttributeSet to allow modifications. Ignoring any errors as they will be caught above
-	private, _ := public.Copy()
+	// Copy the AttributeSet to allow modifications.
+	private := public.Copy()
 
 	return c.GenerateECDSAKeyPairWithAttributes(public, private, curve)
 }
 
 // GenerateECDSAKeyPairWithAttributes generates an ECDSA key pair on the token. Required Attributes that are missing
 // in the provided "public" and "private" AttributeSets will be set to a default value.
-func (c *Context) GenerateECDSAKeyPairWithAttributes(public, private *AttributeSet, curve elliptic.Curve) (k Signer, err error) {
+func (c *Context) GenerateECDSAKeyPairWithAttributes(public, private AttributeSet, curve elliptic.Curve) (k Signer, err error) {
 	if c.closed.Get() {
 		return nil, errClosed
 	}

--- a/ecdsa.go
+++ b/ecdsa.go
@@ -206,11 +206,14 @@ func (c *Context) GenerateECDSAKeyPair(id []byte, curve elliptic.Curve) (Signer,
 		return nil, errClosed
 	}
 
-	template, err := NewAttributeSetWithId(id)
+	public, err := NewAttributeSetWithId(id)
 	if err != nil {
 		return nil, err
 	}
-	return c.GenerateECDSAKeyPairWithAttributes(template, template.Copy(), curve)
+	// Copy the AttributeSet to allow modifications. Ignoring any errors as they will be caught above
+	private, _ := public.Copy()
+
+	return c.GenerateECDSAKeyPairWithAttributes(public, private, curve)
 }
 
 // GenerateECDSAKeyPairWithLabel creates a ECDSA key pair on the token using curve c. The id and label parameters are used to
@@ -221,11 +224,14 @@ func (c *Context) GenerateECDSAKeyPairWithLabel(id, label []byte, curve elliptic
 		return nil, errClosed
 	}
 
-	template, err := NewAttributeSetWithIDAndLabel(id, label)
+	public, err := NewAttributeSetWithIDAndLabel(id, label)
 	if err != nil {
 		return nil, err
 	}
-	return c.GenerateECDSAKeyPairWithAttributes(template, template.Copy(), curve)
+	// Copy the AttributeSet to allow modifications. Ignoring any errors as they will be caught above
+	private, _ := public.Copy()
+
+	return c.GenerateECDSAKeyPairWithAttributes(public, private, curve)
 }
 
 // GenerateECDSAKeyPairWithAttributes generates an ECDSA key pair on the token. Required Attributes that are missing

--- a/rsa.go
+++ b/rsa.go
@@ -93,8 +93,8 @@ func (c *Context) GenerateRSAKeyPair(id []byte, bits int) (SignerDecrypter, erro
 	if err != nil {
 		return nil, err
 	}
-	// Copy the AttributeSet to allow modifications. Ignoring any errors as they will be caught above
-	private, _ := public.Copy()
+	// Copy the AttributeSet to allow modifications.
+	private := public.Copy()
 
 	return c.GenerateRSAKeyPairWithAttributes(public, private, bits)
 }
@@ -111,15 +111,15 @@ func (c *Context) GenerateRSAKeyPairWithLabel(id, label []byte, bits int) (Signe
 	if err != nil {
 		return nil, err
 	}
-	// Copy the AttributeSet to allow modifications. Ignoring any errors as they will be caught above
-	private, _ := public.Copy()
+	// Copy the AttributeSet to allow modifications.
+	private := public.Copy()
 
 	return c.GenerateRSAKeyPairWithAttributes(public, private, bits)
 }
 
 // GenerateRSAKeyPairWithAttributes generates an RSA key pair on the token. Required Attributes that are missing
 // in the provided "public" and "private" AttributeSets will be set to a default value.
-func (c *Context) GenerateRSAKeyPairWithAttributes(public, private *AttributeSet, bits int) (key SignerDecrypter, err error) {
+func (c *Context) GenerateRSAKeyPairWithAttributes(public, private AttributeSet, bits int) (key SignerDecrypter, err error) {
 	if c.closed.Get() {
 		return nil, errClosed
 	}

--- a/rsa.go
+++ b/rsa.go
@@ -89,11 +89,14 @@ func (c *Context) GenerateRSAKeyPair(id []byte, bits int) (SignerDecrypter, erro
 		return nil, errClosed
 	}
 
-	template, err := NewAttributeSetWithId(id)
+	public, err := NewAttributeSetWithId(id)
 	if err != nil {
 		return nil, err
 	}
-	return c.GenerateRSAKeyPairWithAttributes(template, template.Copy(), bits)
+	// Copy the AttributeSet to allow modifications. Ignoring any errors as they will be caught above
+	private, _ := public.Copy()
+
+	return c.GenerateRSAKeyPairWithAttributes(public, private, bits)
 }
 
 // GenerateRSAKeyPairWithLabel creates an RSA key pair on the token. The id and label parameters are used to
@@ -104,11 +107,14 @@ func (c *Context) GenerateRSAKeyPairWithLabel(id, label []byte, bits int) (Signe
 		return nil, errClosed
 	}
 
-	template, err := NewAttributeSetWithIDAndLabel(id, label)
+	public, err := NewAttributeSetWithIDAndLabel(id, label)
 	if err != nil {
 		return nil, err
 	}
-	return c.GenerateRSAKeyPairWithAttributes(template, template.Copy(), bits)
+	// Copy the AttributeSet to allow modifications. Ignoring any errors as they will be caught above
+	private, _ := public.Copy()
+
+	return c.GenerateRSAKeyPairWithAttributes(public, private, bits)
 }
 
 // GenerateRSAKeyPairWithAttributes generates an RSA key pair on the token. Required Attributes that are missing

--- a/symmetric.go
+++ b/symmetric.go
@@ -283,7 +283,7 @@ func (c *Context) GenerateSecretKeyWithLabel(id, label []byte, bits int, cipher 
 
 // GenerateSecretKeyWithAttributes creates an secret key of given length and type. Required Attributes that are missing
 // in the provided "template" AttributeSet will be set to a default value.
-func (c *Context) GenerateSecretKeyWithAttributes(template *AttributeSet, bits int, cipher *SymmetricCipher) (k *SecretKey, err error) {
+func (c *Context) GenerateSecretKeyWithAttributes(template AttributeSet, bits int, cipher *SymmetricCipher) (k *SecretKey, err error) {
 	if c.closed.Get() {
 		return nil, errClosed
 	}


### PR DESCRIPTION
Implements #41 by extending the changes from the with-attributes branch. Most of the change is just boiler plate code to the various key generation functions. The bulk of the changes is to the new helper functions and types to make working with Attributes easier. 

**Summary of new changes:**
- Converted the Attribute type into an alias for the pkcs11.Attribute type to allow for direct conversion between the 2 types. Did the same for the AttributeType type.
- Added NewAttributewith... functions to simplify the common attribute generation functions
- Created an AttributeSet type to provide some common APIs (Add, Append, Merge, Copy, AddDefaults) when working with Attributes. These APIs return a pointer to the struct to allow for chaining the methods.
- Removed the code that returned the modified Attribute slices since the new AttributeSet is mutable and will contain the added Attributes after the call.