### PR TITLE
Support importing and finding certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is an implementation of the standard Golang crypto interfaces that
 uses [PKCS#11](http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/errata01/os/pkcs11-base-v2.40-errata01-os-complete.html) as a backend. The supported features are:
 
 * Generation and retrieval of RSA, DSA and ECDSA keys.
+* Importing and retrieval of x509 certificates
 * PKCS#1 v1.5 signing.
 * PKCS#1 PSS signing.
 * PKCS#1 v1.5 decryption

--- a/certificates.go
+++ b/certificates.go
@@ -1,0 +1,145 @@
+// Copyright 2016, 2017 Thales e-Security, Inc
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package crypto11
+
+import (
+	"crypto/x509"
+	"encoding/asn1"
+
+	"github.com/miekg/pkcs11"
+	"github.com/pkg/errors"
+)
+
+// FindCertificate retrieves a previously imported certificate
+//
+// Either (but not all three) of id, label and serial may be nil, in which case they are ignored.
+// If specified, serial should be the ASN.1 Integer DER-encoding of the certificate serial number.
+func (c *Context) FindCertificate(id []byte, label []byte, serial []byte) (*x509.Certificate, error) {
+	var handles []pkcs11.ObjectHandle
+	var template []*pkcs11.Attribute
+
+	if c.closed.Get() {
+		return nil, errClosed
+	}
+
+	var cert *x509.Certificate
+	err := c.withSession(func(session *pkcs11Session) (err error) {
+		if id == nil && label == nil && serial == nil {
+			return errors.New("id, label and serial cannot both be nil")
+		}
+		if id != nil {
+			template = append(template, pkcs11.NewAttribute(pkcs11.CKA_ID, id))
+		}
+		if label != nil {
+			template = append(template, pkcs11.NewAttribute(pkcs11.CKA_LABEL, label))
+		}
+		if serial != nil {
+			template = append(template, pkcs11.NewAttribute(pkcs11.CKA_SERIAL_NUMBER, serial))
+		}
+
+		template = append(template, pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_CERTIFICATE))
+
+		if err = session.ctx.FindObjectsInit(session.handle, template); err != nil {
+			return err
+		}
+		defer func() {
+			finalErr := session.ctx.FindObjectsFinal(session.handle)
+			if err == nil {
+				err = finalErr
+			}
+		}()
+		if handles, _, err = session.ctx.FindObjects(session.handle, 1); err != nil {
+			return err
+		}
+		if len(handles) == 0 {
+			return nil
+		}
+
+		attributes := []*pkcs11.Attribute{
+			pkcs11.NewAttribute(pkcs11.CKA_VALUE, 0),
+		}
+
+		if attributes, err = session.ctx.GetAttributeValue(session.handle, handles[0], attributes); err != nil {
+			return err
+		}
+
+		cert, err = x509.ParseCertificate(attributes[0].Value)
+
+		return err
+	})
+
+	return cert, err
+}
+
+// ImportCertificate imports a certificate onto the token.  he id parameter is used to
+// set CKA_ID and must be non-nil.
+func (c *Context) ImportCertificate(id []byte, certificate *x509.Certificate) error {
+
+	if err := notNilBytes(id, "id"); err != nil {
+		return err
+	}
+
+	return c.importCertificate(id, nil, certificate)
+}
+
+// ImportCertificateWithLabel imports a certificate onto the token.  The id and label parameters are used to
+// set CKA_ID and CKA_LABEL respectively and must be non-nil.
+func (c *Context) ImportCertificateWithLabel(id []byte, label []byte, certificate *x509.Certificate) error {
+
+	if err := notNilBytes(id, "id"); err != nil {
+		return err
+	}
+	if err := notNilBytes(label, "label"); err != nil {
+		return err
+	}
+
+	return c.importCertificate(id, label, certificate)
+}
+
+func (c *Context) importCertificate(id []byte, label []byte, certificate *x509.Certificate) error {
+
+	serial, err := asn1.Marshal(certificate.SerialNumber)
+	if err != nil {
+		return err
+	}
+
+	err = c.withSession(func(session *pkcs11Session) (err error) {
+		attributes := []*pkcs11.Attribute{
+			pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_CERTIFICATE),
+			pkcs11.NewAttribute(pkcs11.CKA_CERTIFICATE_TYPE, pkcs11.CKC_X_509),
+			pkcs11.NewAttribute(pkcs11.CKA_TOKEN, true),
+			pkcs11.NewAttribute(pkcs11.CKA_PRIVATE, false),
+			pkcs11.NewAttribute(pkcs11.CKA_SUBJECT, certificate.RawSubject),
+			pkcs11.NewAttribute(pkcs11.CKA_ISSUER, certificate.RawIssuer),
+			pkcs11.NewAttribute(pkcs11.CKA_LABEL, label),
+			pkcs11.NewAttribute(pkcs11.CKA_ID, id),
+			pkcs11.NewAttribute(pkcs11.CKA_SERIAL_NUMBER, serial),
+			pkcs11.NewAttribute(pkcs11.CKA_VALUE, certificate.Raw),
+		}
+
+		_, err = session.ctx.CreateObject(session.handle, attributes)
+
+		return err
+	})
+
+	return err
+}

--- a/certificates.go
+++ b/certificates.go
@@ -139,6 +139,10 @@ func (c *Context) ImportCertificateWithLabel(id []byte, label []byte, certificat
 // will contain the attributes applied to the certificate. If required attributes are missing, they will be set to a
 // default value.
 func (c *Context) ImportCertificateWithAttributes(template AttributeSet, certificate *x509.Certificate) error {
+	if c.closed.Get() {
+		return errClosed
+	}
+
 	if certificate == nil {
 		return errors.New("certificate cannot be nil")
 	}

--- a/certificates_test.go
+++ b/certificates_test.go
@@ -22,7 +22,6 @@
 package crypto11
 
 import (
-	"bytes"
 	"crypto/x509"
 	"encoding/pem"
 	"testing"
@@ -68,34 +67,29 @@ func TestCertificate(t *testing.T) {
 	label := randomBytes()
 
 	block, _ := pem.Decode([]byte(testCertificate))
-	assert.NotNil(t, block.Bytes)
+	require.NotNil(t, block.Bytes)
 
 	cert, err := x509.ParseCertificate(block.Bytes)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = ctx.ImportCertificateWithLabel(id, label, cert)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	cert2, err := ctx.FindCertificate(nil, label, nil)
-	assert.NoError(t, err)
-	assert.NotNil(t, cert2)
+	require.NoError(t, err)
+	require.NotNil(t, cert2)
 
-	if !bytes.Equal(cert2.Signature, cert.Signature) {
-		t.Errorf("invalid certificate")
-		return
-	}
+	assert.Equal(t, cert.Signature, cert2.Signature)
 
 	cert2, err = ctx.FindCertificate(nil, []byte("test2"), nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, cert2)
 
-	cert2, err = ctx.FindCertificate(nil, nil, cert.SerialNumber.Bytes())
-	assert.NoError(t, err)
-	assert.NotNil(t, cert2)
+	cert2, err = ctx.FindCertificate(nil, nil, cert.SerialNumber)
+	require.NoError(t, err)
+	require.NotNil(t, cert2)
 
-	ok := bytes.Equal(cert2.Signature, cert.Signature)
-	assert.True(t, ok)
-
+	assert.Equal(t, cert.Signature, cert2.Signature)
 }
 
 func TestCertificateRequiredArgs(t *testing.T) {

--- a/certificates_test.go
+++ b/certificates_test.go
@@ -1,0 +1,122 @@
+// Copyright 2018 Thales e-Security, Inc
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package crypto11
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testCertificate = `-----BEGIN CERTIFICATE----- 
+MIID6TCCA1ICAQEwDQYJKoZIhvcNAQEFBQAwgYsxCzAJBgNVBAYTAlVTMRMwEQYD
+VQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMRQwEgYDVQQK
+EwtHb29nbGUgSW5jLjEMMAoGA1UECxMDRW5nMQwwCgYDVQQDEwNhZ2wxHTAbBgkq 
+hkiG9w0BCQEWDmFnbEBnb29nbGUuY29tMB4XDTA5MDkwOTIyMDU0M1oXDTEwMDkw  
+OTIyMDU0M1owajELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAf  	  
+BgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDEjMCEGA1UEAxMaZXVyb3Bh		  
+LnNmby5jb3JwLmdvb2dsZS5jb20wggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIK
+AoICAQC6pgYt7/EibBDumASF+S0qvqdL/f+nouJw2T1Qc8GmXF/iiUcrsgzh/Fd8
+pDhz/T96Qg9IyR4ztuc2MXrmPra+zAuSf5bevFReSqvpIt8Duv0HbDbcqs/XKPfB
+uMDe+of7a9GCywvAZ4ZUJcp0thqD9fKTTjUWOBzHY1uNE4RitrhmJCrbBGXbJ249
+bvgmb7jgdInH2PU7PT55hujvOoIsQW2osXBFRur4pF1wmVh4W4lTLD6pjfIMUcML
+ICHEXEN73PDic8KS3EtNYCwoIld+tpIBjE1QOb1KOyuJBNW6Esw9ALZn7stWdYcE
+qAwvv20egN2tEXqj7Q4/1ccyPZc3PQgC3FJ8Be2mtllM+80qf4dAaQ/fWvCtOrQ5
+pnfe9juQvCo8Y0VGlFcrSys/MzSg9LJ/24jZVgzQved/Qupsp89wVidwIzjt+WdS
+fyWfH0/v1aQLvu5cMYuW//C0W2nlYziL5blETntM8My2ybNARy3ICHxCBv2RNtPI
+WQVm+E9/W5rwh2IJR4DHn2LHwUVmT/hHNTdBLl5Uhwr4Wc7JhE7AVqb14pVNz1lr
+5jxsp//ncIwftb7mZQ3DF03Yna+jJhpzx8CQoeLT6aQCHyzmH68MrHHT4MALPyUs
+Pomjn71GNTtDeWAXibjCgdL6iHACCF6Htbl0zGlG0OAK+bdn0QIDAQABMA0GCSqG
+SIb3DQEBBQUAA4GBAOKnQDtqBV24vVqvesL5dnmyFpFPXBn3WdFfwD6DzEb21UVG
+5krmJiu+ViipORJPGMkgoL6BjU21XI95VQbun5P8vvg8Z+FnFsvRFY3e1CCzAVQY
+ZsUkLw2I7zI/dNlWdB8Xp7v+3w9sX5N3J/WuJ1KOO5m26kRlHQo7EzT3974g
+-----END CERTIFICATE-----   
+`
+
+func TestCertificate(t *testing.T) {
+	ctx, err := ConfigureFromFile("config")
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, ctx.Close())
+	}()
+
+	id := randomBytes()
+	label := randomBytes()
+
+	block, _ := pem.Decode([]byte(testCertificate))
+	assert.NotNil(t, block.Bytes)
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	assert.NoError(t, err)
+
+	err = ctx.ImportCertificateWithLabel(id, label, cert)
+	assert.NoError(t, err)
+
+	cert2, err := ctx.FindCertificate(nil, label, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, cert2)
+
+	if !bytes.Equal(cert2.Signature, cert.Signature) {
+		t.Errorf("invalid certificate")
+		return
+	}
+
+	cert2, err = ctx.FindCertificate(nil, []byte("test2"), nil)
+	assert.NoError(t, err)
+	assert.Nil(t, cert2)
+
+	cert2, err = ctx.FindCertificate(nil, nil, cert.SerialNumber.Bytes())
+	assert.NoError(t, err)
+	assert.NotNil(t, cert2)
+
+	ok := bytes.Equal(cert2.Signature, cert.Signature)
+	assert.True(t, ok)
+
+}
+
+func TestCertificateRequiredArgs(t *testing.T) {
+	ctx, err := ConfigureFromFile("config")
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, ctx.Close())
+	}()
+
+	block, _ := pem.Decode([]byte(testCertificate))
+	assert.NotNil(t, block.Bytes)
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	assert.NoError(t, err)
+
+	val := randomBytes()
+
+	err = ctx.ImportCertificateWithLabel(nil, val, cert)
+	require.Error(t, err)
+
+	err = ctx.ImportCertificateWithLabel(val, nil, cert)
+	require.Error(t, err)
+}

--- a/certificates_test.go
+++ b/certificates_test.go
@@ -113,4 +113,7 @@ func TestCertificateRequiredArgs(t *testing.T) {
 
 	err = ctx.ImportCertificateWithLabel(val, nil, cert)
 	require.Error(t, err)
+
+	err = ctx.ImportCertificateWithLabel(val, val, nil)
+	require.Error(t, err)
 }

--- a/close_test.go
+++ b/close_test.go
@@ -24,8 +24,6 @@ package crypto11
 import (
 	"crypto/dsa"
 	"crypto/elliptic"
-	"crypto/x509"
-	"encoding/pem"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -113,11 +111,7 @@ func TestErrorAfterClosed(t *testing.T) {
 	_, err = ctx.NewRandomReader()
 	require.Equal(t, errClosed, err)
 
-	block, _ := pem.Decode([]byte(testCertificate))
-	require.NotNil(t, block.Bytes)
-
-	cert, err := x509.ParseCertificate(block.Bytes)
-	require.NoError(t, err)
+	cert := generateRandomCert(t)
 
 	err = ctx.ImportCertificate(bytes, cert)
 	require.Equal(t, errClosed, err)

--- a/close_test.go
+++ b/close_test.go
@@ -24,6 +24,8 @@ package crypto11
 import (
 	"crypto/dsa"
 	"crypto/elliptic"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -109,5 +111,17 @@ func TestErrorAfterClosed(t *testing.T) {
 	require.Equal(t, errClosed, err)
 
 	_, err = ctx.NewRandomReader()
+	require.Equal(t, errClosed, err)
+
+	block, _ := pem.Decode([]byte(testCertificate))
+	require.NotNil(t, block.Bytes)
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+
+	err = ctx.ImportCertificate(bytes, cert)
+	require.Equal(t, errClosed, err)
+
+	err = ctx.ImportCertificateWithLabel(bytes, bytes, cert)
 	require.Equal(t, errClosed, err)
 }

--- a/close_test.go
+++ b/close_test.go
@@ -29,6 +29,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -79,43 +81,46 @@ func TestErrorAfterClosed(t *testing.T) {
 	bytes := randomBytes()
 
 	_, err = ctx.FindKey(bytes, nil)
-	require.Equal(t, errClosed, err)
+	assert.Equal(t, errClosed, err)
 
 	_, err = ctx.FindKeyPair(bytes, nil)
-	require.Equal(t, errClosed, err)
+	assert.Equal(t, errClosed, err)
 
 	_, err = ctx.GenerateSecretKey(bytes, 256, CipherAES)
-	require.Equal(t, errClosed, err)
+	assert.Equal(t, errClosed, err)
 
 	_, err = ctx.GenerateSecretKeyWithLabel(bytes, bytes, 256, CipherAES)
-	require.Equal(t, errClosed, err)
+	assert.Equal(t, errClosed, err)
 
 	_, err = ctx.GenerateRSAKeyPair(bytes, 2048)
-	require.Equal(t, errClosed, err)
+	assert.Equal(t, errClosed, err)
 
 	_, err = ctx.GenerateRSAKeyPairWithLabel(bytes, bytes, 2048)
-	require.Equal(t, errClosed, err)
+	assert.Equal(t, errClosed, err)
 
 	_, err = ctx.GenerateDSAKeyPair(bytes, dsaSizes[dsa.L1024N160])
-	require.Equal(t, errClosed, err)
+	assert.Equal(t, errClosed, err)
 
 	_, err = ctx.GenerateDSAKeyPairWithLabel(bytes, bytes, dsaSizes[dsa.L1024N160])
-	require.Equal(t, errClosed, err)
+	assert.Equal(t, errClosed, err)
 
 	_, err = ctx.GenerateECDSAKeyPair(bytes, elliptic.P224())
-	require.Equal(t, errClosed, err)
+	assert.Equal(t, errClosed, err)
 
 	_, err = ctx.GenerateECDSAKeyPairWithLabel(bytes, bytes, elliptic.P224())
-	require.Equal(t, errClosed, err)
+	assert.Equal(t, errClosed, err)
 
 	_, err = ctx.NewRandomReader()
-	require.Equal(t, errClosed, err)
+	assert.Equal(t, errClosed, err)
 
 	cert := generateRandomCert(t)
 
 	err = ctx.ImportCertificate(bytes, cert)
-	require.Equal(t, errClosed, err)
+	assert.Equal(t, errClosed, err)
 
 	err = ctx.ImportCertificateWithLabel(bytes, bytes, cert)
-	require.Equal(t, errClosed, err)
+	assert.Equal(t, errClosed, err)
+
+	err = ctx.ImportCertificateWithAttributes(NewAttributeSet(), cert)
+	assert.Equal(t, errClosed, err)
 }

--- a/sessions.go
+++ b/sessions.go
@@ -23,6 +23,7 @@ package crypto11
 
 import (
 	"context"
+	"errors"
 
 	"github.com/miekg/pkcs11"
 	"github.com/vitessio/vitess/go/pools"
@@ -65,8 +66,10 @@ func (c *Context) getSession() (*pkcs11Session, error) {
 
 	resource, err := c.pool.Get(ctx)
 	if err == pools.ErrClosed {
-		// Our Context must have been closed, return a nicer error
-		return nil, errClosed
+		// Our Context must have been closed, return a nicer error.
+		// We don't use errClosed to ensure our tests identify functions that aren't checking for closure
+		// correctly.
+		return nil, errors.New("context is closed")
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR includes the work from @bernard-wagner to import and find X.509 certificates.

Additional changes introduce a WithAttributes variant, to match the key generation functions.

Fixes #21.