### PR TITLE
Remove dependency on Vitess

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,4 +153,3 @@ discuss.
 Here are some topics we'd like to cover:
 
 * Full test instructions for additional PKCS#11 implementations.
-* Move to another resource pool implementation (`github.com/vitessio/vitess` is a big dependency)

--- a/crypto11.go
+++ b/crypto11.go
@@ -97,11 +97,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/vitessio/vitess/go/sync2"
-
 	"github.com/miekg/pkcs11"
 	"github.com/pkg/errors"
-	"github.com/vitessio/vitess/go/pools"
+	"github.com/thales-e-security/pool"
 )
 
 const (
@@ -164,14 +162,14 @@ func (k *pkcs11PrivateKey) Delete() error {
 // All functions, except Close, are safe to call from multiple goroutines.
 type Context struct {
 	// Atomic fields must be at top (according to the package owners)
-	closed sync2.AtomicBool
+	closed pool.AtomicBool
 
 	ctx *pkcs11.Ctx
 	cfg *Config
 
 	token *pkcs11.TokenInfo
 	slot  uint
-	pool  *pools.ResourcePool
+	pool  *pool.ResourcePool
 
 	// persistentSession is a session held open so we can be confident handles and login status
 	// persist for the duration of this context
@@ -317,7 +315,7 @@ func Configure(config *Config) (*Context, error) {
 	}
 
 	// We will use one session to keep state alive, so the pool gets maxSessions - 1
-	instance.pool = pools.NewResourcePool(instance.resourcePoolFactoryFunc, maxSessions-1, maxSessions-1, 0)
+	instance.pool = pool.NewResourcePool(instance.resourcePoolFactoryFunc, maxSessions-1, maxSessions-1, 0, 0)
 
 	// Create a long-term session and log it in (if supported). This session won't be used by callers, instead it is
 	// used to keep a connection alive to the token to ensure object handles and the log in status remain accessible.

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,8 @@ module github.com/ThalesIgnite/crypto11
 go 1.12
 
 require (
-	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/miekg/pkcs11 v1.0.3-0.20190429190417-a667d056470f
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
-	github.com/vitessio/vitess v2.1.1+incompatible
-	github.com/youtube/vitess v2.1.1+incompatible // indirect
-	golang.org/x/net v0.0.0-20190424112056-4829fb13d2c6 // indirect
+	github.com/thales-e-security/pool v0.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,5 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
-github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
-github.com/miekg/pkcs11 v1.0.2 h1:CIBkOawOtzJNE0B+EpRiUBzuVW7JEQAwdwhSS6YhIeg=
-github.com/miekg/pkcs11 v1.0.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/miekg/pkcs11 v1.0.3-0.20190429190417-a667d056470f h1:eVB9ELsoq5ouItQBr5Tj334bhPJG/MX+m7rTchmzVUQ=
 github.com/miekg/pkcs11 v1.0.3-0.20190429190417-a667d056470f/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
@@ -13,12 +9,5 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/vitessio/vitess v2.1.1+incompatible h1:zE9Moh7xCrFDpniUsYPVoiOWtdTK0TWoHUjwFV7iFCA=
-github.com/vitessio/vitess v2.1.1+incompatible/go.mod h1:A11WWLimUfZAYYm8P1I63RryRPP2GdpHRgQcfa++OnQ=
-github.com/youtube/vitess v2.1.1+incompatible h1:SE+P7DNX/jw5RHFs5CHRhZQjq402EJFCD33JhzQMdDw=
-github.com/youtube/vitess v2.1.1+incompatible/go.mod h1:hpMim5/30F1r+0P8GGtB29d0gWHr0IZ5unS+CG0zMx8=
-golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/net v0.0.0-20190424112056-4829fb13d2c6 h1:FP8hkuE6yUEaJnK7O2eTuejKWwW+Rhfj80dQ2JcKxCU=
-golang.org/x/net v0.0.0-20190424112056-4829fb13d2c6/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+github.com/thales-e-security/pool v0.0.1 h1:1eJJNN2K/mAzwfr546brAiQVa3UaRC0gGENsHM8veS8=
+github.com/thales-e-security/pool v0.0.1/go.mod h1:qtpMm2+thHtqhLzTwgDBj/OuNnMpupY8mv0Phz0gjhU=

--- a/sessions.go
+++ b/sessions.go
@@ -26,7 +26,7 @@ import (
 	"errors"
 
 	"github.com/miekg/pkcs11"
-	"github.com/vitessio/vitess/go/pools"
+	"github.com/thales-e-security/pool"
 )
 
 // pkcs11Session wraps a PKCS#11 session handle so we can use it in a resource pool.
@@ -65,7 +65,7 @@ func (c *Context) getSession() (*pkcs11Session, error) {
 	}
 
 	resource, err := c.pool.Get(ctx)
-	if err == pools.ErrClosed {
+	if err == pool.ErrClosed {
 		// Our Context must have been closed, return a nicer error.
 		// We don't use errClosed to ensure our tests identify functions that aren't checking for closure
 		// correctly.
@@ -79,7 +79,7 @@ func (c *Context) getSession() (*pkcs11Session, error) {
 }
 
 // resourcePoolFactoryFunc is called by the resource pool when a new session is needed.
-func (c *Context) resourcePoolFactoryFunc() (pools.Resource, error) {
+func (c *Context) resourcePoolFactoryFunc() (pool.Resource, error) {
 	session, err := c.ctx.OpenSession(c.slot, pkcs11.CKF_SERIAL_SESSION|pkcs11.CKF_RW_SESSION)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This change removes dependencies on Vitess (with associated problems, see #56). Instead, we use a clone of the interesting parts of Vitess, now at https://github.com/thales-e-security/pool.

Closes #56.