### PR TITLE
Changes to support AWS CloudHSM

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ A minimal configuration file looks like this:
 Testing Guidance
 ================
 
+Disabling tests
+---------------
+
+To disable specific tests, set the environment variable `CRYPTO11_SKIP=<flags>` where `<flags>` is a comma-separated
+list of the following options:
+
+*  `CERTS` - disables certificate-related tests. Needed for AWS CloudHSM, which doesn't support certificates. 
+
+
 Testing with SoftHSM2
 ---------------------
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ Disabling tests
 To disable specific tests, set the environment variable `CRYPTO11_SKIP=<flags>` where `<flags>` is a comma-separated
 list of the following options:
 
-*  `CERTS` - disables certificate-related tests. Needed for AWS CloudHSM, which doesn't support certificates. 
+*  `CERTS` - disables certificate-related tests. Needed for AWS CloudHSM, which doesn't support certificates.
+*  `OAEP_LABEL` - disables RSA OAEP encryption tests that use source data encoding parameter (also known as a 'label' 
+in some crypto libraries). Needed for AWS CloudHSM.
 
 
 Testing with SoftHSM2

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ list of the following options:
 *  `CERTS` - disables certificate-related tests. Needed for AWS CloudHSM, which doesn't support certificates.
 *  `OAEP_LABEL` - disables RSA OAEP encryption tests that use source data encoding parameter (also known as a 'label' 
 in some crypto libraries). Needed for AWS CloudHSM.
+*  `DSA` - disables DSA tests. Needed for AWS CloudHSM (and any other tokens not supporting DSA).
 
 
 Testing with SoftHSM2

--- a/aead.go
+++ b/aead.go
@@ -49,7 +49,9 @@ type genericAead struct {
 
 	nonceSize int
 
-	makeMech func(nonce []byte, additionalData []byte) ([]*pkcs11.Mechanism, error)
+	// Note - if the GCMParams result is non-nil, the caller must call Free() on the params when
+	// finished.
+	makeMech func(nonce []byte, additionalData []byte) ([]*pkcs11.Mechanism, *pkcs11.GCMParams, error)
 }
 
 // NewGCM returns a given cipher wrapped in Galois Counter Mode, with the standard
@@ -66,9 +68,9 @@ func (key *SecretKey) NewGCM() (cipher.AEAD, error) {
 		key:       key,
 		overhead:  16,
 		nonceSize: 12,
-		makeMech: func(nonce []byte, additionalData []byte) ([]*pkcs11.Mechanism, error) {
+		makeMech: func(nonce []byte, additionalData []byte) ([]*pkcs11.Mechanism, *pkcs11.GCMParams, error) {
 			params := pkcs11.NewGCMParams(nonce, additionalData, 16*8 /*bits*/)
-			return []*pkcs11.Mechanism{pkcs11.NewMechanism(key.Cipher.GCMMech, params)}, nil
+			return []*pkcs11.Mechanism{pkcs11.NewMechanism(key.Cipher.GCMMech, params)}, params, nil
 		},
 	}
 	return g, nil
@@ -96,12 +98,12 @@ func (key *SecretKey) NewCBC(paddingMode PaddingMode) (cipher.AEAD, error) {
 		key:       key,
 		overhead:  0,
 		nonceSize: key.BlockSize(),
-		makeMech: func(nonce []byte, additionalData []byte) ([]*pkcs11.Mechanism, error) {
+		makeMech: func(nonce []byte, additionalData []byte) ([]*pkcs11.Mechanism, *pkcs11.GCMParams, error) {
 			if len(additionalData) > 0 {
-				return nil, errors.New("additional data not supported for CBC mode")
+				return nil, nil, errors.New("additional data not supported for CBC mode")
 			}
 
-			return []*pkcs11.Mechanism{pkcs11.NewMechanism(pkcsMech, nonce)}, nil
+			return []*pkcs11.Mechanism{pkcs11.NewMechanism(pkcsMech, nonce)}, nil, nil
 		},
 	}
 
@@ -119,10 +121,12 @@ func (g genericAead) Overhead() int {
 func (g genericAead) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
 	var result []byte
 	if err := g.key.context.withSession(func(session *pkcs11Session) (err error) {
-		var mech []*pkcs11.Mechanism
-		if mech, err = g.makeMech(nonce, additionalData); err != nil {
-			return
+		mech, params, err := g.makeMech(nonce, additionalData)
+		if err != nil {
+			return err
 		}
+		defer params.Free()
+
 		if err = session.ctx.EncryptInit(session.handle, mech, g.key.handle); err != nil {
 			err = fmt.Errorf("C_EncryptInit: %v", err)
 			return
@@ -131,6 +135,11 @@ func (g genericAead) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
 			err = fmt.Errorf("C_Encrypt: %v", err)
 			return
 		}
+
+		if g.key.context.cfg.UseGCMIVFromHSM {
+			copy(nonce, params.IV())
+		}
+
 		return
 	}); err != nil {
 		panic(err)
@@ -143,10 +152,12 @@ func (g genericAead) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
 func (g genericAead) Open(dst, nonce, ciphertext, additionalData []byte) ([]byte, error) {
 	var result []byte
 	if err := g.key.context.withSession(func(session *pkcs11Session) (err error) {
-		var mech []*pkcs11.Mechanism
-		if mech, err = g.makeMech(nonce, additionalData); err != nil {
+		mech, params, err := g.makeMech(nonce, additionalData)
+		if err != nil {
 			return
 		}
+		defer params.Free()
+
 		if err = session.ctx.DecryptInit(session.handle, mech, g.key.handle); err != nil {
 			err = fmt.Errorf("C_DecryptInit: %v", err)
 			return

--- a/attributes.go
+++ b/attributes.go
@@ -192,6 +192,19 @@ func (a AttributeSet) Set(attributeType AttributeType, value interface{}) error 
 	return nil
 }
 
+// cloneFrom make this AttributeSet a clone of the supplied set. Values are deep copied.
+func (a AttributeSet) cloneFrom(set AttributeSet) {
+	for key := range a {
+		delete(a, key)
+	}
+
+	// Use Copy to do the deep cloning for us
+	c := set.Copy()
+	for k, v := range c {
+		a[k] = v
+	}
+}
+
 // AddIfNotPresent adds the attributes if the Attribute Type is not already present in the AttributeSet.
 func (a AttributeSet) AddIfNotPresent(additional []*Attribute) {
 	for _, additionalAttr := range additional {

--- a/attributes.go
+++ b/attributes.go
@@ -221,6 +221,12 @@ func (a AttributeSet) Copy() AttributeSet {
 	return b
 }
 
+// Unset removes an attribute from the attributes set. If the set does not contain the attribute, this
+// is a no-op.
+func (a AttributeSet) Unset(attributeType AttributeType) {
+	delete(a, attributeType)
+}
+
 // NewAttributeSetWithID is a helper function that populates a new slice of Attributes with the provided ID.
 // This function returns an error if the ID is an empty slice.
 func NewAttributeSetWithID(id []byte) (AttributeSet, error) {

--- a/attributes.go
+++ b/attributes.go
@@ -3,6 +3,7 @@ package crypto11
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/miekg/pkcs11"
 )
@@ -13,7 +14,7 @@ type AttributeType = uint
 // Attribute represents a PKCS#11 CK_ATTRIBUTE type.
 type Attribute = pkcs11.Attribute
 
-//noinspection GoUnusedConst
+//noinspection GoUnusedConst,GoDeprecation
 const (
 	CkaClass                  = AttributeType(0x00000000)
 	CkaToken                  = AttributeType(0x00000001)
@@ -227,6 +228,14 @@ func (a AttributeSet) Unset(attributeType AttributeType) {
 	delete(a, attributeType)
 }
 
+func (a AttributeSet) String() string {
+	result := new(strings.Builder)
+	for attr, value := range a {
+		_, _ = fmt.Fprintf(result, "%s: %x\n", attributeTypeString(attr), value.Value)
+	}
+	return result.String()
+}
+
 // NewAttributeSetWithID is a helper function that populates a new slice of Attributes with the provided ID.
 // This function returns an error if the ID is an empty slice.
 func NewAttributeSetWithID(id []byte) (AttributeSet, error) {
@@ -251,4 +260,238 @@ func NewAttributeSetWithIDAndLabel(id, label []byte) (a AttributeSet, err error)
 
 	_ = a.Set(CkaLabel, label) // error not possible with []byte
 	return a, nil
+}
+
+func attributeTypeString(a AttributeType) string {
+	//noinspection GoDeprecation
+	switch a {
+	case CkaClass:
+		return "CkaClass"
+	case CkaToken:
+		return "CkaToken"
+	case CkaPrivate:
+		return "CkaPrivate"
+	case CkaLabel:
+		return "CkaLabel"
+	case CkaApplication:
+		return "CkaApplication"
+	case CkaValue:
+		return "CkaValue"
+	case CkaObjectId:
+		return "CkaObjectId"
+	case CkaCertificateType:
+		return "CkaCertificateType"
+	case CkaIssuer:
+		return "CkaIssuer"
+	case CkaSerialNumber:
+		return "CkaSerialNumber"
+	case CkaAcIssuer:
+		return "CkaAcIssuer"
+	case CkaOwner:
+		return "CkaOwner"
+	case CkaAttrTypes:
+		return "CkaAttrTypes"
+	case CkaTrusted:
+		return "CkaTrusted"
+	case CkaCertificateCategory:
+		return "CkaCertificateCategory"
+	case CkaJavaMIDPSecurityDomain:
+		return "CkaJavaMIDPSecurityDomain"
+	case CkaUrl:
+		return "CkaUrl"
+	case CkaHashOfSubjectPublicKey:
+		return "CkaHashOfSubjectPublicKey"
+	case CkaHashOfIssuerPublicKey:
+		return "CkaHashOfIssuerPublicKey"
+	case CkaNameHashAlgorithm:
+		return "CkaNameHashAlgorithm"
+	case CkaCheckValue:
+		return "CkaCheckValue"
+
+	case CkaKeyType:
+		return "CkaKeyType"
+	case CkaSubject:
+		return "CkaSubject"
+	case CkaId:
+		return "CkaId"
+	case CkaSensitive:
+		return "CkaSensitive"
+	case CkaEncrypt:
+		return "CkaEncrypt"
+	case CkaDecrypt:
+		return "CkaDecrypt"
+	case CkaWrap:
+		return "CkaWrap"
+	case CkaUnwrap:
+		return "CkaUnwrap"
+	case CkaSign:
+		return "CkaSign"
+	case CkaSignRecover:
+		return "CkaSignRecover"
+	case CkaVerify:
+		return "CkaVerify"
+	case CkaVerifyRecover:
+		return "CkaVerifyRecover"
+	case CkaDerive:
+		return "CkaDerive"
+	case CkaStartDate:
+		return "CkaStartDate"
+	case CkaEndDate:
+		return "CkaEndDate"
+	case CkaModulus:
+		return "CkaModulus"
+	case CkaModulusBits:
+		return "CkaModulusBits"
+	case CkaPublicExponent:
+		return "CkaPublicExponent"
+	case CkaPrivateExponent:
+		return "CkaPrivateExponent"
+	case CkaPrime1:
+		return "CkaPrime1"
+	case CkaPrime2:
+		return "CkaPrime2"
+	case CkaExponent1:
+		return "CkaExponent1"
+	case CkaExponent2:
+		return "CkaExponent2"
+	case CkaCoefficient:
+		return "CkaCoefficient"
+	case CkaPublicKeyInfo:
+		return "CkaPublicKeyInfo"
+	case CkaPrime:
+		return "CkaPrime"
+	case CkaSubprime:
+		return "CkaSubprime"
+	case CkaBase:
+		return "CkaBase"
+
+	case CkaPrimeBits:
+		return "CkaPrimeBits"
+	case CkaSubprimeBits:
+		return "CkaSubprimeBits"
+
+	case CkaValueBits:
+		return "CkaValueBits"
+	case CkaValueLen:
+		return "CkaValueLen"
+	case CkaExtractable:
+		return "CkaExtractable"
+	case CkaLocal:
+		return "CkaLocal"
+	case CkaNeverExtractable:
+		return "CkaNeverExtractable"
+	case CkaAlwaysSensitive:
+		return "CkaAlwaysSensitive"
+	case CkaKeyGenMechanism:
+		return "CkaKeyGenMechanism"
+
+	case CkaModifiable:
+		return "CkaModifiable"
+	case CkaCopyable:
+		return "CkaCopyable"
+
+	case CkaDestroyable:
+		return "CkaDestroyable"
+
+	case CkaEcParams:
+		return "CkaEcParams"
+
+	case CkaEcPoint:
+		return "CkaEcPoint"
+
+	case CkaSecondaryAuth:
+		return "CkaSecondaryAuth"
+	case CkaAuthPinFlags:
+		return "CkaAuthPinFlags"
+
+	case CkaAlwaysAuthenticate:
+		return "CkaAlwaysAuthenticate"
+
+	case CkaWrapWithTrusted:
+		return "CkaWrapWithTrusted"
+
+	case ckfArrayAttribute:
+		return "ckfArrayAttribute"
+
+	case CkaWrapTemplate:
+		return "CkaWrapTemplate"
+	case CkaUnwrapTemplate:
+		return "CkaUnwrapTemplate"
+
+	case CkaOtpFormat:
+		return "CkaOtpFormat"
+	case CkaOtpLength:
+		return "CkaOtpLength"
+	case CkaOtpTimeInterval:
+		return "CkaOtpTimeInterval"
+	case CkaOtpUserFriendlyMode:
+		return "CkaOtpUserFriendlyMode"
+	case CkaOtpChallengeRequirement:
+		return "CkaOtpChallengeRequirement"
+	case CkaOtpTimeRequirement:
+		return "CkaOtpTimeRequirement"
+	case CkaOtpCounterRequirement:
+		return "CkaOtpCounterRequirement"
+	case CkaOtpPinRequirement:
+		return "CkaOtpPinRequirement"
+	case CkaOtpCounter:
+		return "CkaOtpCounter"
+	case CkaOtpTime:
+		return "CkaOtpTime"
+	case CkaOtpUserIdentifier:
+		return "CkaOtpUserIdentifier"
+	case CkaOtpServiceIdentifier:
+		return "CkaOtpServiceIdentifier"
+	case CkaOtpServiceLogo:
+		return "CkaOtpServiceLogo"
+	case CkaOtpServiceLogoType:
+		return "CkaOtpServiceLogoType"
+
+	case CkaGOSTR3410Params:
+		return "CkaGOSTR3410Params"
+	case CkaGOSTR3411Params:
+		return "CkaGOSTR3411Params"
+	case CkaGOST28147Params:
+		return "CkaGOST28147Params"
+
+	case CkaHwFeatureType:
+		return "CkaHwFeatureType"
+	case CkaResetOnInit:
+		return "CkaResetOnInit"
+	case CkaHasReset:
+		return "CkaHasReset"
+
+	case CkaPixelX:
+		return "CkaPixelX"
+	case CkaPixelY:
+		return "CkaPixelY"
+	case CkaResolution:
+		return "CkaResolution"
+	case CkaCharRows:
+		return "CkaCharRows"
+	case CkaCharColumns:
+		return "CkaCharColumns"
+	case CkaColor:
+		return "CkaColor"
+	case CkaBitsPerPixel:
+		return "CkaBitsPerPixel"
+	case CkaCharSets:
+		return "CkaCharSets"
+	case CkaEncodingMethods:
+		return "CkaEncodingMethods"
+	case CkaMimeTypes:
+		return "CkaMimeTypes"
+	case CkaMechanismType:
+		return "CkaMechanismType"
+	case CkaRequiredCmsAttributes:
+		return "CkaRequiredCmsAttributes"
+	case CkaDefaultCmsAttributes:
+		return "CkaDefaultCmsAttributes"
+	case CkaSupportedCmsAttributes:
+		return "CkaSupportedCmsAttributes"
+	case CkaAllowedMechanisms:
+		return "CkaAllowedMechanisms"
+	default:
+		return "Unknown"
+	}
 }

--- a/certificates_test.go
+++ b/certificates_test.go
@@ -28,6 +28,8 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"math/big"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -35,7 +37,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const skipTestEnv = "CRYPTO11_SKIP"
+
+const skipTestCert = "CERTS"
+
+// skipTest tests whether the CRYPTO11_SKIP environment variable contains
+// flagName. If so, it skips the test.
+func skipTest(t *testing.T, flagName string) {
+	thingsToSkip := strings.Split(os.Getenv(skipTestEnv), ",")
+	for _, s := range thingsToSkip {
+		if s == flagName {
+			t.Logf("Skipping test due to %s flag", flagName)
+			t.SkipNow()
+		}
+	}
+}
+
 func TestCertificate(t *testing.T) {
+	skipTest(t, skipTestCert)
+
 	ctx, err := ConfigureFromFile("config")
 	require.NoError(t, err)
 
@@ -70,6 +90,8 @@ func TestCertificate(t *testing.T) {
 
 // Test that provided attributes override default values
 func TestCertificateAttributes(t *testing.T) {
+	skipTest(t, skipTestCert)
+
 	ctx, err := ConfigureFromFile("config")
 	require.NoError(t, err)
 
@@ -103,6 +125,8 @@ func TestCertificateAttributes(t *testing.T) {
 }
 
 func TestCertificateRequiredArgs(t *testing.T) {
+	skipTest(t, skipTestCert)
+
 	ctx, err := ConfigureFromFile("config")
 	require.NoError(t, err)
 

--- a/certificates_test.go
+++ b/certificates_test.go
@@ -28,30 +28,12 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"math/big"
-	"os"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-const skipTestEnv = "CRYPTO11_SKIP"
-
-const skipTestCert = "CERTS"
-
-// skipTest tests whether the CRYPTO11_SKIP environment variable contains
-// flagName. If so, it skips the test.
-func skipTest(t *testing.T, flagName string) {
-	thingsToSkip := strings.Split(os.Getenv(skipTestEnv), ",")
-	for _, s := range thingsToSkip {
-		if s == flagName {
-			t.Logf("Skipping test due to %s flag", flagName)
-			t.SkipNow()
-		}
-	}
-}
 
 func TestCertificate(t *testing.T) {
 	skipTest(t, skipTestCert)

--- a/close_test.go
+++ b/close_test.go
@@ -42,9 +42,11 @@ func TestClose(t *testing.T) {
 
 	const pSize = dsa.L1024N160
 	id := randomBytes()
-	key, err := ctx.GenerateDSAKeyPair(id, dsaSizes[pSize])
-	require.NoError(t, err)
-	require.NotNil(t, key)
+	_, err = ctx.GenerateDSAKeyPair(id, dsaSizes[pSize])
+	if err != nil {
+		_ = ctx.Close()
+		t.Fatal(err)
+	}
 
 	require.NoError(t, ctx.Close())
 
@@ -61,7 +63,7 @@ func TestClose(t *testing.T) {
 			err = key2.Delete()
 			require.NoError(t, err)
 		}
-		
+
 		require.NoError(t, ctx.Close())
 	}
 }

--- a/close_test.go
+++ b/close_test.go
@@ -24,7 +24,6 @@ package crypto11
 import (
 	"crypto/dsa"
 	"crypto/elliptic"
-	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -40,9 +39,8 @@ func TestClose(t *testing.T) {
 	ctx, err := ConfigureFromFile("config")
 	require.NoError(t, err)
 
-	const pSize = dsa.L1024N160
 	id := randomBytes()
-	_, err = ctx.GenerateDSAKeyPair(id, dsaSizes[pSize])
+	_, err = ctx.GenerateRSAKeyPair(id, rsaSize)
 	if err != nil {
 		_ = ctx.Close()
 		t.Fatal(err)
@@ -57,8 +55,7 @@ func TestClose(t *testing.T) {
 		key2, err := ctx.FindKeyPair(id, nil)
 		require.NoError(t, err)
 
-		testDsaSigning(t, key2.(*pkcs11PrivateKeyDSA), pSize, fmt.Sprintf("close%d", i))
-
+		testRsaSigning(t, key2, false)
 		if i == 4 {
 			err = key2.Delete()
 			require.NoError(t, err)

--- a/close_test.go
+++ b/close_test.go
@@ -48,21 +48,15 @@ func TestClose(t *testing.T) {
 
 	require.NoError(t, ctx.Close())
 
-	for i := 0; i < 5; i++ {
-		ctx, err := ConfigureFromFile("config")
-		require.NoError(t, err)
+	ctx, err = ConfigureFromFile("config")
+	require.NoError(t, err)
 
-		key2, err := ctx.FindKeyPair(id, nil)
-		require.NoError(t, err)
+	key2, err := ctx.FindKeyPair(id, nil)
+	require.NoError(t, err)
 
-		testRsaSigning(t, key2, false)
-		if i == 4 {
-			err = key2.Delete()
-			require.NoError(t, err)
-		}
-
-		require.NoError(t, ctx.Close())
-	}
+	testRsaSigning(t, key2, false)
+	_ = key2.Delete()
+	require.NoError(t, ctx.Close())
 }
 
 // randomBytes returns 32 random bytes.

--- a/close_test.go
+++ b/close_test.go
@@ -24,51 +24,12 @@ package crypto11
 import (
 	"crypto/dsa"
 	"crypto/elliptic"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/stretchr/testify/require"
 )
-
-func TestClose(t *testing.T) {
-	// Verify that close and re-open works.
-
-	ctx, err := ConfigureFromFile("config")
-	require.NoError(t, err)
-
-	id := randomBytes()
-	_, err = ctx.GenerateRSAKeyPair(id, rsaSize)
-	if err != nil {
-		_ = ctx.Close()
-		t.Fatal(err)
-	}
-
-	require.NoError(t, ctx.Close())
-
-	ctx, err = ConfigureFromFile("config")
-	require.NoError(t, err)
-
-	key2, err := ctx.FindKeyPair(id, nil)
-	require.NoError(t, err)
-
-	testRsaSigning(t, key2, false)
-	_ = key2.Delete()
-	require.NoError(t, ctx.Close())
-}
-
-// randomBytes returns 32 random bytes.
-func randomBytes() []byte {
-	result := make([]byte, 32)
-	rand.Read(result)
-	return result
-}
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 func TestErrorAfterClosed(t *testing.T) {
 	ctx, err := ConfigureFromFile("config")

--- a/crypto11.go
+++ b/crypto11.go
@@ -242,6 +242,12 @@ type Config struct {
 
 	// LoginNotSupported should be set to true for tokens that do not support logging in.
 	LoginNotSupported bool
+
+	// UseGCMIVFromHSM should be set to true for tokens such as CloudHSM, which ignore the supplied IV for
+	// GCM mode and generate their own. In this case, the token will write the IV used into the CK_GCM_PARAMS.
+	// If UseGCMIVFromHSM is true, we will copy this IV and overwrite the 'nonce' slice passed to Seal and Open. It
+	// is therefore necessary that the nonce is the correct length (12 bytes for CloudHSM).
+	UseGCMIVFromHSM bool
 }
 
 // refCount counts the number of contexts using a particular P11 library. It must not be read or modified

--- a/crypto11_test.go
+++ b/crypto11_test.go
@@ -22,7 +22,6 @@
 package crypto11
 
 import (
-	"crypto/dsa"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -39,37 +38,28 @@ import (
 )
 
 func TestKeysPersistAcrossContexts(t *testing.T) {
-	ctx, err := configureWithPin(t)
+	// Verify that close and re-open works.
+	ctx, err := ConfigureFromFile("config")
 	require.NoError(t, err)
 
-	defer func() {
-		err = ctx.Close()
-		require.NoError(t, err)
-	}()
-
-	// Generate a key and and close a session
-	const pSize = dsa.L1024N160
 	id := randomBytes()
-	key, err := ctx.GenerateDSAKeyPair(id, dsaSizes[pSize])
-	require.NoError(t, err)
-	require.NotNil(t, key)
+	_, err = ctx.GenerateRSAKeyPair(id, rsaSize)
+	if err != nil {
+		_ = ctx.Close()
+		t.Fatal(err)
+	}
 
-	err = ctx.Close()
-	require.NoError(t, err)
+	require.NoError(t, ctx.Close())
 
-	// Reopen a session and try to find a key.
-	// Valid session must enlist a key.
-	// If login is not performed than it will fail.
-	ctx, err = configureWithPin(t)
+	ctx, err = ConfigureFromFile("config")
 	require.NoError(t, err)
 
 	key2, err := ctx.FindKeyPair(id, nil)
 	require.NoError(t, err)
 
-	testDsaSigning(t, key2.(*pkcs11PrivateKeyDSA), pSize, fmt.Sprintf("close%d", 0))
-
-	err = key2.Delete()
-	require.NoError(t, err)
+	testRsaSigning(t, key2, false)
+	_ = key2.Delete()
+	require.NoError(t, ctx.Close())
 }
 
 func configureWithPin(t *testing.T) (*Context, error) {
@@ -286,4 +276,15 @@ func TestNoLogin(t *testing.T) {
 	require.True(t, ok)
 
 	assert.Equal(t, pkcs11.Error(pkcs11.CKR_USER_NOT_LOGGED_IN), p11Err)
+}
+
+// randomBytes returns 32 random bytes.
+func randomBytes() []byte {
+	result := make([]byte, 32)
+	rand.Read(result)
+	return result
+}
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
 }

--- a/dsa_test.go
+++ b/dsa_test.go
@@ -118,7 +118,7 @@ func TestHardDSA(t *testing.T) {
 
 		key, err := ctx.GenerateDSAKeyPairWithLabel(id, label, params)
 		require.NoError(t, err, "Failed for key size %s", parameterSizeToString(pSize))
-		defer func() { _ = key.Delete() }()
+		defer func(k Signer) { _ = k.Delete() }(key)
 
 		testDsaSigning(t, key, pSize, "hard1")
 

--- a/dsa_test.go
+++ b/dsa_test.go
@@ -115,9 +115,8 @@ func TestHardDSA(t *testing.T) {
 		label := randomBytes()
 
 		key, err := ctx.GenerateDSAKeyPairWithLabel(id, label, params)
-		require.NoError(t, err)
-		require.NotNil(t, key)
-		defer key.Delete()
+		require.NoError(t, err, "Failed for key size %s", parameterSizeToString(pSize))
+		defer func() { _ = key.Delete() }()
 
 		testDsaSigning(t, key, pSize, "hard1")
 
@@ -128,6 +127,21 @@ func TestHardDSA(t *testing.T) {
 		key3, err := ctx.FindKeyPair(nil, label)
 		require.NoError(t, err)
 		testDsaSigning(t, key3.(crypto.Signer), pSize, "hard3")
+	}
+}
+
+func parameterSizeToString(s dsa.ParameterSizes) string {
+	switch s {
+	case dsa.L1024N160:
+		return "L1024N160"
+	case dsa.L2048N224:
+		return "L2048N224"
+	case dsa.L2048N256:
+		return "L2048N256"
+	case dsa.L3072N256:
+		return "L3072N256"
+	default:
+		return "unknown"
 	}
 }
 

--- a/dsa_test.go
+++ b/dsa_test.go
@@ -101,6 +101,8 @@ func TestNativeDSA(t *testing.T) {
 }
 
 func TestHardDSA(t *testing.T) {
+	skipTest(t, skipTestDSA)
+
 	ctx, err := ConfigureFromFile("config")
 	require.NoError(t, err)
 

--- a/ecdsa_test.go
+++ b/ecdsa_test.go
@@ -31,6 +31,8 @@ import (
 	_ "crypto/sha512"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,11 +52,11 @@ func TestNativeECDSA(t *testing.T) {
 			t.Errorf("crypto.ecdsa.GenerateKey: %v", err)
 			return
 		}
-		testEcdsaSigning(t, key, crypto.SHA1)
-		testEcdsaSigning(t, key, crypto.SHA224)
-		testEcdsaSigning(t, key, crypto.SHA256)
-		testEcdsaSigning(t, key, crypto.SHA384)
-		testEcdsaSigning(t, key, crypto.SHA512)
+		testEcdsaSigning(t, key, crypto.SHA1, curve.Params().Name, "SHA-1")
+		testEcdsaSigning(t, key, crypto.SHA224, curve.Params().Name, "SHA-224")
+		testEcdsaSigning(t, key, crypto.SHA256, curve.Params().Name, "SHA-256")
+		testEcdsaSigning(t, key, crypto.SHA384, curve.Params().Name, "SHA-384")
+		testEcdsaSigning(t, key, crypto.SHA512, curve.Params().Name, "SHA-512")
 	}
 }
 
@@ -76,32 +78,37 @@ func TestHardECDSA(t *testing.T) {
 		require.NotNil(t, key)
 		defer key.Delete()
 
-		testEcdsaSigning(t, key, crypto.SHA1)
-		testEcdsaSigning(t, key, crypto.SHA224)
-		testEcdsaSigning(t, key, crypto.SHA256)
-		testEcdsaSigning(t, key, crypto.SHA384)
-		testEcdsaSigning(t, key, crypto.SHA512)
+		testEcdsaSigning(t, key, crypto.SHA1, curve.Params().Name, "SHA-1")
+		testEcdsaSigning(t, key, crypto.SHA224, curve.Params().Name, "SHA-224")
+		testEcdsaSigning(t, key, crypto.SHA256, curve.Params().Name, "SHA-256")
+		testEcdsaSigning(t, key, crypto.SHA384, curve.Params().Name, "SHA-384")
+		testEcdsaSigning(t, key, crypto.SHA512, curve.Params().Name, "SHA-512")
 
 		key2, err := ctx.FindKeyPair(id, nil)
 		require.NoError(t, err)
-		testEcdsaSigning(t, key2.(*pkcs11PrivateKeyECDSA), crypto.SHA256)
+		testEcdsaSigning(t, key2.(*pkcs11PrivateKeyECDSA), crypto.SHA256, curve.Params().Name, "SHA-256")
 
 		key3, err := ctx.FindKeyPair(nil, label)
 		require.NoError(t, err)
-		testEcdsaSigning(t, key3.(crypto.Signer), crypto.SHA384)
+		testEcdsaSigning(t, key3.(crypto.Signer), crypto.SHA384, curve.Params().Name, "SHA-384")
 	}
 }
 
-func testEcdsaSigning(t *testing.T, key crypto.Signer, hashFunction crypto.Hash) {
+func testEcdsaSigning(t *testing.T, key crypto.Signer, hashFunction crypto.Hash, curveName, hashName string) {
 
 	plaintext := []byte("sign me with ECDSA")
 	h := hashFunction.New()
 	_, err := h.Write(plaintext)
 	require.NoError(t, err)
-	plaintextHash := h.Sum([]byte{}) // weird API
+	plaintextHash := h.Sum(nil)
 
 	sigDER, err := key.Sign(rand.Reader, plaintextHash, nil)
-	require.NoError(t, err)
+	assert.NoErrorf(t, err, "Sign failed for curve %s and hash %s", curveName, hashName)
+	if err != nil {
+		// We assert and return, so that errors are more informative over a range of curves
+		// and hashes.
+		return
+	}
 
 	var sig dsaSignature
 	err = sig.unmarshalDER(sigDER)

--- a/hmac_test.go
+++ b/hmac_test.go
@@ -57,6 +57,8 @@ func TestHmac(t *testing.T) {
 
 func testHmac(t *testing.T, ctx *Context, keytype int, mech int, length int, xlength int, full bool) {
 
+	skipIfMechUnsupported(t, ctx, uint(mech))
+
 	id := randomBytes()
 	key, err := ctx.GenerateSecretKey(id, 256, Ciphers[keytype])
 	require.NoError(t, err)

--- a/keys.go
+++ b/keys.go
@@ -337,7 +337,11 @@ func (c *Context) FindKeyPairsWithAttributes(attributes AttributeSet) (signer []
 		return nil
 	})
 
-	return keys, err
+	if err != nil {
+		return nil, err
+	}
+
+	return keys, nil
 }
 
 // FindAllKeyPairs retrieves all existing asymmetric key pairs, or a nil slice if none can be found.
@@ -474,7 +478,10 @@ func (c *Context) FindKeysWithAttributes(attributes AttributeSet) ([]*SecretKey,
 		return nil
 	})
 
-	return keys, err
+	if err != nil {
+		return nil, err
+	}
+	return keys, nil
 }
 
 // FindAllKeyPairs retrieves all existing symmetric keys, or a nil slice if none can be found.

--- a/keys_test.go
+++ b/keys_test.go
@@ -44,15 +44,15 @@ func TestFindingKeysWithAttributes(t *testing.T) {
 
 		key, err := ctx.GenerateSecretKey(id, 128, CipherAES)
 		require.NoError(t, err)
-		defer key.Delete()
+		defer func() { _ = key.Delete() }()
 
 		key, err = ctx.GenerateSecretKey(id2, 128, CipherAES)
 		require.NoError(t, err)
-		defer key.Delete()
+		defer func() { _ = key.Delete() }()
 
 		key, err = ctx.GenerateSecretKey(id2, 256, CipherAES)
 		require.NoError(t, err)
-		defer key.Delete()
+		defer func() { _ = key.Delete() }()
 
 		attrs, err := NewAttributeSetWithID(id)
 		require.NoError(t, err)
@@ -87,17 +87,17 @@ func TestFindingKeyPairsWithAttributes(t *testing.T) {
 		id := randomBytes()
 		id2 := randomBytes()
 
-		key, err := ctx.GenerateRSAKeyPair(id, 1024)
+		key, err := ctx.GenerateRSAKeyPair(id, rsaSize)
 		require.NoError(t, err)
-		defer key.Delete()
+		defer func() { _ = key.Delete() }()
 
-		key, err = ctx.GenerateRSAKeyPair(id2, 1024)
+		key, err = ctx.GenerateRSAKeyPair(id2, rsaSize)
 		require.NoError(t, err)
-		defer key.Delete()
+		defer func() { _ = key.Delete() }()
 
-		key, err = ctx.GenerateRSAKeyPair(id2, 2048)
+		key, err = ctx.GenerateRSAKeyPair(id2, rsaSize)
 		require.NoError(t, err)
-		defer key.Delete()
+		defer func() { _ = key.Delete() }()
 
 		attrs, err := NewAttributeSetWithID(id)
 		require.NoError(t, err)
@@ -127,7 +127,7 @@ func TestFindingAllKeys(t *testing.T) {
 			key, err := ctx.GenerateSecretKey(id, 128, CipherAES)
 			require.NoError(t, err)
 
-			defer key.Delete()
+			defer func() { _ = key.Delete() }()
 		}
 
 		keys, err := ctx.FindAllKeys()
@@ -142,10 +142,10 @@ func TestFindingAllKeyPairs(t *testing.T) {
 	withContext(t, func(ctx *Context) {
 		for i := 1; i <= 5; i++ {
 			id := randomBytes()
-			key, err := ctx.GenerateRSAKeyPair(id, 1024)
+			key, err := ctx.GenerateRSAKeyPair(id, rsaSize)
 			require.NoError(t, err)
 
-			defer key.Delete()
+			defer func() { _ = key.Delete() }()
 		}
 
 		keys, err := ctx.FindAllKeyPairs()
@@ -160,9 +160,9 @@ func TestGettingPrivateKeyAttributes(t *testing.T) {
 	withContext(t, func(ctx *Context) {
 		id := randomBytes()
 
-		key, err := ctx.GenerateRSAKeyPair(id, 1024)
+		key, err := ctx.GenerateRSAKeyPair(id, rsaSize)
 		require.NoError(t, err)
-		defer key.Delete()
+		defer func() { _ = key.Delete() }()
 
 		attrs, err := ctx.GetAttributes(key, []AttributeType{CkaModulus})
 		require.NoError(t, err)
@@ -177,16 +177,16 @@ func TestGettingPublicKeyAttributes(t *testing.T) {
 	withContext(t, func(ctx *Context) {
 		id := randomBytes()
 
-		key, err := ctx.GenerateRSAKeyPair(id, 1024)
+		key, err := ctx.GenerateRSAKeyPair(id, rsaSize)
 		require.NoError(t, err)
-		defer key.Delete()
+		defer func() { _ = key.Delete() }()
 
 		attrs, err := ctx.GetPubAttributes(key, []AttributeType{CkaModulusBits})
 		require.NoError(t, err)
 		require.NotNil(t, attrs)
 		require.Len(t, attrs, 1)
 
-		require.Equal(t, uint(1024), bytesToUlong(attrs[CkaModulusBits].Value))
+		require.Equal(t, uint(rsaSize), bytesToUlong(attrs[CkaModulusBits].Value))
 	})
 }
 
@@ -196,7 +196,7 @@ func TestGettingSecretKeyAttributes(t *testing.T) {
 
 		key, err := ctx.GenerateSecretKey(id, 128, CipherAES)
 		require.NoError(t, err)
-		defer key.Delete()
+		defer func() { _ = key.Delete() }()
 
 		attrs, err := ctx.GetAttributes(key, []AttributeType{CkaValueLen})
 		require.NoError(t, err)
@@ -209,7 +209,7 @@ func TestGettingSecretKeyAttributes(t *testing.T) {
 
 func TestGettingUnsupportedKeyTypeAttributes(t *testing.T) {
 	withContext(t, func(ctx *Context) {
-		key, err := rsa.GenerateKey(rand.Reader, 1024)
+		key, err := rsa.GenerateKey(rand.Reader, rsaSize)
 		require.NoError(t, err)
 
 		_, err = ctx.GetAttributes(key, []AttributeType{CkaModulusBits})

--- a/keys_test.go
+++ b/keys_test.go
@@ -39,30 +39,27 @@ func TestFindKeysRequiresIdOrLabel(t *testing.T) {
 
 func TestFindingKeysWithAttributes(t *testing.T) {
 	withContext(t, func(ctx *Context) {
-		id := randomBytes()
-		id2 := randomBytes()
+		label := randomBytes()
+		label2 := randomBytes()
 
-		key, err := ctx.GenerateSecretKey(id, 128, CipherAES)
+		key, err := ctx.GenerateSecretKeyWithLabel(randomBytes(), label, 128, CipherAES)
 		require.NoError(t, err)
 		defer func(k *SecretKey) { _ = k.Delete() }(key)
 
-		key, err = ctx.GenerateSecretKey(id2, 128, CipherAES)
+		key, err = ctx.GenerateSecretKeyWithLabel(randomBytes(), label2, 128, CipherAES)
 		require.NoError(t, err)
 		defer func(k *SecretKey) { _ = k.Delete() }(key)
 
-		key, err = ctx.GenerateSecretKey(id2, 256, CipherAES)
+		key, err = ctx.GenerateSecretKeyWithLabel(randomBytes(), label2, 256, CipherAES)
 		require.NoError(t, err)
 		defer func(k *SecretKey) { _ = k.Delete() }(key)
 
-		attrs, err := NewAttributeSetWithID(id)
-		require.NoError(t, err)
-
+		attrs := NewAttributeSet()
+		_ = attrs.Set(CkaLabel, label)
 		keys, err := ctx.FindKeysWithAttributes(attrs)
 		require.Len(t, keys, 1)
 
-		attrs, err = NewAttributeSetWithID(id2)
-		require.NoError(t, err)
-
+		_ = attrs.Set(CkaLabel, label2)
 		keys, err = ctx.FindKeysWithAttributes(attrs)
 		require.Len(t, keys, 2)
 
@@ -84,30 +81,31 @@ func TestFindingKeysWithAttributes(t *testing.T) {
 
 func TestFindingKeyPairsWithAttributes(t *testing.T) {
 	withContext(t, func(ctx *Context) {
-		id := randomBytes()
-		id2 := randomBytes()
 
-		key, err := ctx.GenerateRSAKeyPair(id, rsaSize)
+		// Note: we use common labels, not IDs in this test code. AWS CloudHSM
+		// does not accept two keys with the same ID.
+
+		label := randomBytes()
+		label2 := randomBytes()
+
+		key, err := ctx.GenerateRSAKeyPairWithLabel(randomBytes(), label, rsaSize)
 		require.NoError(t, err)
 		defer func(k Signer) { _ = k.Delete() }(key)
 
-		key, err = ctx.GenerateRSAKeyPair(id2, rsaSize)
+		key, err = ctx.GenerateRSAKeyPairWithLabel(randomBytes(), label2, rsaSize)
 		require.NoError(t, err)
 		defer func(k Signer) { _ = k.Delete() }(key)
 
-		key, err = ctx.GenerateRSAKeyPair(id2, rsaSize)
+		key, err = ctx.GenerateRSAKeyPairWithLabel(randomBytes(), label2, rsaSize)
 		require.NoError(t, err)
 		defer func(k Signer) { _ = k.Delete() }(key)
 
-		attrs, err := NewAttributeSetWithID(id)
-		require.NoError(t, err)
-
+		attrs := NewAttributeSet()
+		_ = attrs.Set(CkaLabel, label)
 		keys, err := ctx.FindKeyPairsWithAttributes(attrs)
 		require.Len(t, keys, 1)
 
-		attrs, err = NewAttributeSetWithID(id2)
-		require.NoError(t, err)
-
+		_ = attrs.Set(CkaLabel, label2)
 		keys, err = ctx.FindKeyPairsWithAttributes(attrs)
 		require.Len(t, keys, 2)
 

--- a/keys_test.go
+++ b/keys_test.go
@@ -59,10 +59,12 @@ func TestFindingKeysWithAttributes(t *testing.T) {
 		attrs := NewAttributeSet()
 		_ = attrs.Set(CkaLabel, label)
 		keys, err := ctx.FindKeysWithAttributes(attrs)
+		require.NoError(t, err)
 		require.Len(t, keys, 1)
 
 		_ = attrs.Set(CkaLabel, label2)
 		keys, err = ctx.FindKeysWithAttributes(attrs)
+		require.NoError(t, err)
 		require.Len(t, keys, 2)
 
 		attrs = NewAttributeSet()
@@ -70,6 +72,7 @@ func TestFindingKeysWithAttributes(t *testing.T) {
 		require.NoError(t, err)
 
 		keys, err = ctx.FindKeysWithAttributes(attrs)
+		require.NoError(t, err)
 		require.Len(t, keys, 2)
 
 		attrs = NewAttributeSet()
@@ -77,6 +80,7 @@ func TestFindingKeysWithAttributes(t *testing.T) {
 		require.NoError(t, err)
 
 		keys, err = ctx.FindKeysWithAttributes(attrs)
+		require.NoError(t, err)
 		require.Len(t, keys, 1)
 	})
 }
@@ -105,17 +109,18 @@ func TestFindingKeyPairsWithAttributes(t *testing.T) {
 		attrs := NewAttributeSet()
 		_ = attrs.Set(CkaLabel, label)
 		keys, err := ctx.FindKeyPairsWithAttributes(attrs)
+		require.NoError(t, err)
 		require.Len(t, keys, 1)
 
 		_ = attrs.Set(CkaLabel, label2)
 		keys, err = ctx.FindKeyPairsWithAttributes(attrs)
+		require.NoError(t, err)
 		require.Len(t, keys, 2)
 
 		attrs = NewAttributeSet()
-		err = attrs.Set(CkaKeyType, pkcs11.CKK_RSA)
-		require.NoError(t, err)
-
+		_ = attrs.Set(CkaKeyType, pkcs11.CKK_RSA)
 		keys, err = ctx.FindKeyPairsWithAttributes(attrs)
+		require.NoError(t, err)
 		require.Len(t, keys, 3)
 	})
 }

--- a/keys_test.go
+++ b/keys_test.go
@@ -44,15 +44,15 @@ func TestFindingKeysWithAttributes(t *testing.T) {
 
 		key, err := ctx.GenerateSecretKey(id, 128, CipherAES)
 		require.NoError(t, err)
-		defer func() { _ = key.Delete() }()
+		defer func(k *SecretKey) { _ = k.Delete() }(key)
 
 		key, err = ctx.GenerateSecretKey(id2, 128, CipherAES)
 		require.NoError(t, err)
-		defer func() { _ = key.Delete() }()
+		defer func(k *SecretKey) { _ = k.Delete() }(key)
 
 		key, err = ctx.GenerateSecretKey(id2, 256, CipherAES)
 		require.NoError(t, err)
-		defer func() { _ = key.Delete() }()
+		defer func(k *SecretKey) { _ = k.Delete() }(key)
 
 		attrs, err := NewAttributeSetWithID(id)
 		require.NoError(t, err)
@@ -89,15 +89,15 @@ func TestFindingKeyPairsWithAttributes(t *testing.T) {
 
 		key, err := ctx.GenerateRSAKeyPair(id, rsaSize)
 		require.NoError(t, err)
-		defer func() { _ = key.Delete() }()
+		defer func(k Signer) { _ = k.Delete() }(key)
 
 		key, err = ctx.GenerateRSAKeyPair(id2, rsaSize)
 		require.NoError(t, err)
-		defer func() { _ = key.Delete() }()
+		defer func(k Signer) { _ = k.Delete() }(key)
 
 		key, err = ctx.GenerateRSAKeyPair(id2, rsaSize)
 		require.NoError(t, err)
-		defer func() { _ = key.Delete() }()
+		defer func(k Signer) { _ = k.Delete() }(key)
 
 		attrs, err := NewAttributeSetWithID(id)
 		require.NoError(t, err)
@@ -127,7 +127,7 @@ func TestFindingAllKeys(t *testing.T) {
 			key, err := ctx.GenerateSecretKey(id, 128, CipherAES)
 			require.NoError(t, err)
 
-			defer func() { _ = key.Delete() }()
+			defer func(k *SecretKey) { _ = k.Delete() }(key)
 		}
 
 		keys, err := ctx.FindAllKeys()
@@ -145,7 +145,7 @@ func TestFindingAllKeyPairs(t *testing.T) {
 			key, err := ctx.GenerateRSAKeyPair(id, rsaSize)
 			require.NoError(t, err)
 
-			defer func() { _ = key.Delete() }()
+			defer func(k Signer) { _ = k.Delete() }(key)
 		}
 
 		keys, err := ctx.FindAllKeyPairs()
@@ -162,14 +162,14 @@ func TestGettingPrivateKeyAttributes(t *testing.T) {
 
 		key, err := ctx.GenerateRSAKeyPair(id, rsaSize)
 		require.NoError(t, err)
-		defer func() { _ = key.Delete() }()
+		defer func(k Signer) { _ = k.Delete() }(key)
 
 		attrs, err := ctx.GetAttributes(key, []AttributeType{CkaModulus})
 		require.NoError(t, err)
 		require.NotNil(t, attrs)
 		require.Len(t, attrs, 1)
 
-		require.Len(t, attrs[CkaModulus].Value, 128)
+		require.Len(t, attrs[CkaModulus].Value, 256)
 	})
 }
 
@@ -179,7 +179,7 @@ func TestGettingPublicKeyAttributes(t *testing.T) {
 
 		key, err := ctx.GenerateRSAKeyPair(id, rsaSize)
 		require.NoError(t, err)
-		defer func() { _ = key.Delete() }()
+		defer func(k Signer) { _ = k.Delete() }(key)
 
 		attrs, err := ctx.GetPubAttributes(key, []AttributeType{CkaModulusBits})
 		require.NoError(t, err)
@@ -196,7 +196,7 @@ func TestGettingSecretKeyAttributes(t *testing.T) {
 
 		key, err := ctx.GenerateSecretKey(id, 128, CipherAES)
 		require.NoError(t, err)
-		defer func() { _ = key.Delete() }()
+		defer func(k *SecretKey) { _ = k.Delete() }(key)
 
 		attrs, err := ctx.GetAttributes(key, []AttributeType{CkaValueLen})
 		require.NoError(t, err)

--- a/keys_test.go
+++ b/keys_test.go
@@ -5,6 +5,8 @@ import (
 	"crypto/rsa"
 	"testing"
 
+	"github.com/miekg/pkcs11"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -110,7 +112,7 @@ func TestFindingKeyPairsWithAttributes(t *testing.T) {
 		require.Len(t, keys, 2)
 
 		attrs = NewAttributeSet()
-		err = attrs.Set(CkaPublicExponent, []byte{1, 0, 1})
+		err = attrs.Set(CkaKeyType, pkcs11.CKK_RSA)
 		require.NoError(t, err)
 
 		keys, err = ctx.FindKeyPairsWithAttributes(attrs)

--- a/rand_test.go
+++ b/rand_test.go
@@ -39,8 +39,8 @@ func TestRandomReader(t *testing.T) {
 	reader, err := ctx.NewRandomReader()
 	require.NoError(t, err)
 
-	var a [32768]byte
-	for _, size := range []int{1, 16, 32, 256, 347, 4096, 32768} {
+	var a [8192]byte
+	for _, size := range []int{1, 16, 32, 256, 347, 4096, 8192} {
 		n, err := reader.Read(a[:size])
 		require.NoError(t, err)
 		require.Equal(t, size, n)

--- a/rsa_test.go
+++ b/rsa_test.go
@@ -240,7 +240,7 @@ func skipIfMechUnsupported(t *testing.T, ctx *Context, wantMech uint) {
 			return
 		}
 	}
-	t.Skipf("mechanism %v not supported", wantMech)
+	t.Skipf("mechanism 0x%x not supported", wantMech)
 }
 
 func TestRsaRequiredArgs(t *testing.T) {

--- a/rsa_test.go
+++ b/rsa_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var rsaSizes = []int{1024, 2048}
+var rsaSizes = []int{2048}
 
 func TestNativeRSA(t *testing.T) {
 
@@ -70,6 +70,7 @@ func TestHardRSA(t *testing.T) {
 	}()
 
 	for _, nbits := range rsaSizes {
+
 		id := randomBytes()
 		label := randomBytes()
 

--- a/skip_test.go
+++ b/skip_test.go
@@ -9,6 +9,7 @@ import (
 const skipTestEnv = "CRYPTO11_SKIP"
 const skipTestCert = "CERTS"
 const skipTestOAEPLabel = "OAEP_LABEL"
+const skipTestDSA = "DSA"
 
 // skipTest tests whether the CRYPTO11_SKIP environment variable contains
 // flagName. If so, it skips the test.

--- a/skip_test.go
+++ b/skip_test.go
@@ -1,0 +1,30 @@
+package crypto11
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+const skipTestEnv = "CRYPTO11_SKIP"
+const skipTestCert = "CERTS"
+const skipTestOAEPLabel = "OAEP_LABEL"
+
+// skipTest tests whether the CRYPTO11_SKIP environment variable contains
+// flagName. If so, it skips the test.
+func skipTest(t *testing.T, flagName string) {
+	if shouldSkipTest(flagName) {
+		t.Logf("Skipping test due to %s flag", flagName)
+		t.SkipNow()
+	}
+}
+
+func shouldSkipTest(flagName string) bool {
+	thingsToSkip := strings.Split(os.Getenv(skipTestEnv), ",")
+	for _, s := range thingsToSkip {
+		if s == flagName {
+			return true
+		}
+	}
+	return false
+}

--- a/symmetric.go
+++ b/symmetric.go
@@ -23,7 +23,6 @@ package crypto11
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/miekg/pkcs11"
 )
@@ -328,8 +327,6 @@ func (c *Context) GenerateSecretKeyWithAttributes(template AttributeSet, bits in
 				adjustedTemplate := template.Copy()
 				adjustedTemplate.Unset(CkaEncrypt)
 				adjustedTemplate.Unset(CkaDecrypt)
-
-				fmt.Println("Adjusted template:\n", adjustedTemplate)
 
 				privHandle, err = session.ctx.GenerateKey(session.handle, mech, adjustedTemplate.ToSlice())
 				if err == nil {

--- a/symmetric.go
+++ b/symmetric.go
@@ -328,7 +328,7 @@ func (c *Context) GenerateSecretKeyWithAttributes(template AttributeSet, bits in
 
 				fmt.Println("Adjusted template:\n", template)
 
-				privHandle, err := session.ctx.GenerateKey(session.handle, mech, template.ToSlice())
+				privHandle, err = session.ctx.GenerateKey(session.handle, mech, template.ToSlice())
 				if err == nil {
 					k = &SecretKey{pkcs11Object{privHandle, c}, cipher}
 					return nil

--- a/symmetric.go
+++ b/symmetric.go
@@ -323,12 +323,13 @@ func (c *Context) GenerateSecretKeyWithAttributes(template AttributeSet, bits in
 			// As a special case, AWS CloudHSM does not accept CKA_ENCRYPT and CKA_DECRYPT on a
 			// Generic Secret key. If we are in that special case, try again without those attributes.
 			if e, ok := err.(pkcs11.Error); ok && e == pkcs11.CKR_ARGUMENTS_BAD && genMech.GenMech == pkcs11.CKM_GENERIC_SECRET_KEY_GEN {
-				template.Unset(CkaEncrypt)
-				template.Unset(CkaDecrypt)
+				adjustedTemplate := template.Copy()
+				adjustedTemplate.Unset(CkaEncrypt)
+				adjustedTemplate.Unset(CkaDecrypt)
 
-				fmt.Println("Adjusted template:\n", template)
+				fmt.Println("Adjusted template:\n", adjustedTemplate)
 
-				privHandle, err = session.ctx.GenerateKey(session.handle, mech, template.ToSlice())
+				privHandle, err = session.ctx.GenerateKey(session.handle, mech, adjustedTemplate.ToSlice())
 				if err == nil {
 					k = &SecretKey{pkcs11Object{privHandle, c}, cipher}
 					return nil

--- a/symmetric.go
+++ b/symmetric.go
@@ -23,6 +23,7 @@ package crypto11
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/miekg/pkcs11"
 )
@@ -324,6 +325,8 @@ func (c *Context) GenerateSecretKeyWithAttributes(template AttributeSet, bits in
 			if e, ok := err.(pkcs11.Error); ok && e == pkcs11.CKR_ARGUMENTS_BAD && genMech.GenMech == pkcs11.CKM_GENERIC_SECRET_KEY_GEN {
 				template.Unset(CkaEncrypt)
 				template.Unset(CkaDecrypt)
+
+				fmt.Println("Adjusted template:\n", template)
 
 				privHandle, err := session.ctx.GenerateKey(session.handle, mech, template.ToSlice())
 				if err == nil {

--- a/symmetric_test.go
+++ b/symmetric_test.go
@@ -73,7 +73,8 @@ func testHardSymmetric(t *testing.T, ctx *Context, keytype int, bits int) {
 	}
 
 	t.Run("CBC", func(t *testing.T) {
-		skipIfMechUnsupported(t, key2.context, key2.Cipher.CBCMech)
+		// By using cipher.NewCBCEncrypter, this test will actually use ECB mode on the key.
+		skipIfMechUnsupported(t, key2.context, key2.Cipher.ECBMech)
 		testSymmetricMode(t, cipher.NewCBCEncrypter(key2, iv), cipher.NewCBCDecrypter(key2, iv))
 	})
 

--- a/symmetric_test.go
+++ b/symmetric_test.go
@@ -46,6 +46,9 @@ func TestHardSymmetric(t *testing.T) {
 }
 
 func testHardSymmetric(t *testing.T, ctx *Context, keytype int, bits int) {
+	for _, p := range Ciphers[keytype].GenParams {
+		skipIfMechUnsupported(t, ctx, p.GenMech)
+	}
 
 	id := randomBytes()
 	key, err := ctx.GenerateSecretKey(id, bits, Ciphers[keytype])

--- a/symmetric_test.go
+++ b/symmetric_test.go
@@ -62,7 +62,10 @@ func testHardSymmetric(t *testing.T, ctx *Context, keytype int, bits int) {
 		require.NoError(t, err)
 	})
 
-	t.Run("Block", func(t *testing.T) { testSymmetricBlock(t, key, key2) })
+	t.Run("Block", func(t *testing.T) {
+		skipIfMechUnsupported(t, key.context, key.Cipher.ECBMech)
+		testSymmetricBlock(t, key, key2)
+	})
 
 	iv := make([]byte, key.BlockSize())
 	for i := range iv {
@@ -70,11 +73,12 @@ func testHardSymmetric(t *testing.T, ctx *Context, keytype int, bits int) {
 	}
 
 	t.Run("CBC", func(t *testing.T) {
+		skipIfMechUnsupported(t, key2.context, key2.Cipher.CBCMech)
 		testSymmetricMode(t, cipher.NewCBCEncrypter(key2, iv), cipher.NewCBCDecrypter(key2, iv))
 	})
 
 	t.Run("CBCClose", func(t *testing.T) {
-
+		skipIfMechUnsupported(t, key2.context, key2.Cipher.CBCMech)
 		enc, err := key2.NewCBCEncrypterCloser(iv)
 		require.NoError(t, err)
 
@@ -87,6 +91,7 @@ func testHardSymmetric(t *testing.T, ctx *Context, keytype int, bits int) {
 	})
 
 	t.Run("CBCNoClose", func(t *testing.T) {
+		skipIfMechUnsupported(t, key2.context, key2.Cipher.CBCMech)
 		enc, err := key2.NewCBCEncrypter(iv)
 		require.NoError(t, err)
 

--- a/symmetric_test.go
+++ b/symmetric_test.go
@@ -130,6 +130,14 @@ func testHardSymmetric(t *testing.T, ctx *Context, keytype int, bits int) {
 }
 
 func testSymmetricBlock(t *testing.T, encryptKey cipher.Block, decryptKey cipher.Block) {
+	// The functions in cipher.Block have no error returns, so they panic if they encounter
+	// a problem. We catch these panics here, so the test can fail nicely
+	defer func() {
+		if cause := recover(); cause != nil {
+			t.Fatalf("Caught panic: %q", cause)
+		}
+	}()
+
 	b := encryptKey.BlockSize()
 	input := make([]byte, 3*b)
 	middle := make([]byte, 3*b)
@@ -179,6 +187,14 @@ func testSymmetricBlock(t *testing.T, encryptKey cipher.Block, decryptKey cipher
 }
 
 func testSymmetricMode(t *testing.T, encrypt cipher.BlockMode, decrypt cipher.BlockMode) {
+	// The functions in cipher.Block have no error returns, so they panic if they encounter
+	// a problem. We catch these panics here, so the test can fail nicely
+	defer func() {
+		if cause := recover(); cause != nil {
+			t.Fatalf("Caught panic: %q", cause)
+		}
+	}()
+
 	input := make([]byte, 256)
 	middle := make([]byte, 256)
 	output := make([]byte, 256)

--- a/thread_test.go
+++ b/thread_test.go
@@ -44,7 +44,7 @@ func TestThreadedRSA(t *testing.T) {
 	id := randomBytes()
 	key, err := ctx.GenerateRSAKeyPair(id, rsaSize)
 	require.NoError(t, err)
-	defer func() { _ = key.Delete() }()
+	defer func(k Signer) { _ = k.Delete() }(key)
 
 	done := make(chan int)
 	started := time.Now()

--- a/thread_test.go
+++ b/thread_test.go
@@ -42,9 +42,9 @@ func TestThreadedRSA(t *testing.T) {
 	}()
 
 	id := randomBytes()
-	key, err := ctx.GenerateRSAKeyPair(id, 1024)
+	key, err := ctx.GenerateRSAKeyPair(id, rsaSize)
 	require.NoError(t, err)
-	defer key.Delete()
+	defer func() { _ = key.Delete() }()
 
 	done := make(chan int)
 	started := time.Now()


### PR DESCRIPTION
A swathe of changes that enable our test suite to execute successfully with AWS CloudHSM, via their PKCS#11 library v2.0.4.

Most changes are to the test code:

- Support was added for skipping classes of tests that are not supported on CloudHSM. Instructions relating to these have been added to the README.
- Additional mechanisms checks have been added, to catch situations where the token cannot support a given algorithm.
- RSA-based tests now use 2048-bit keys, rather than the old mixture of 1024 and 2048.
- Multi-threaded tests are artificially slowed down, to cope with an apparent bug in CloudHSM.
- CloudHSM does not allow keys to have the same `CKA_ID`. As a result, some of the tests have been adjusted to use duplicate `CKA_LABEL` attributes instead of `CKA_ID`.
- The symmetric tests have been made more robust, by catching panics that can occur.

However, there are some changes to non-test code:

- A new Config flag `UseGCMIVFromHSM` has been introduced. When set to `true`, crypto11 assumes the token will generate its own IV for GCM mode, ignoring whatever has been passed in from the client. This is the behaviour of CloudHSM, see footnote 4 on https://docs.aws.amazon.com/cloudhsm/latest/userguide/pkcs11-mechanisms.html.
- CloudHSM will return an empty `CKA_LABEL` for keys that don't have a label, yet throws an error if you pass the empty `CKA_LABEL` back into `C_FindObjectsInit`. To counter this, `keys.go` has some more advanced error handling to spot this case and cope with it.
- Some of the FindKey functions were returning half-finished results, along with an error. This confused me for quite a while, until I realised some of the tests were missing error checks. To avoid this happening to others, these functions now return `nil` data if they are returning an error.
- The parameter marshalling code in `decryptOAEP` was simplified. (I was following a theory that something was broken here, then resolved the issue by adjusting the tests).
- CloudHSM doesn't support `CKA_ENCRYPT` and `CKA_DECRYPT` when generating a generic secret key. I've updated `symmetric.go` to reflect this; catching the error condition and trying again without those variables set. This also squashes a bug that was introduced when we moved to attribute sets, in which the key generation mechanism wasn't been changed on the second time around the loop.
- To support some of the above changes, additional methods were added to the AttributeSet type. This includes a `String()` method, which was useful to me in debugging so I've left it in there.