### PR TITLE
Return error if MaxSessions=1

### DIFF
--- a/crypto11.go
+++ b/crypto11.go
@@ -235,6 +235,7 @@ type Config struct {
 	Pin string
 
 	// Maximum number of concurrent sessions to open. If zero, DefaultMaxSessions is used.
+	// Otherwise, the value specified must be at least 2.
 	MaxSessions int
 
 	// Maximum time to wait for a session from the sessions pool. Zero means wait indefinitely.
@@ -276,6 +277,9 @@ func Configure(config *Config) (*Context, error) {
 
 	if config.MaxSessions == 0 {
 		config.MaxSessions = DefaultMaxSessions
+	}
+	if config.MaxSessions == 1 {
+		return nil, errors.New("MaxSessions must be larger than 1")
 	}
 
 	instance := &Context{

--- a/crypto11_test.go
+++ b/crypto11_test.go
@@ -278,6 +278,15 @@ func TestNoLogin(t *testing.T) {
 	assert.Equal(t, pkcs11.Error(pkcs11.CKR_USER_NOT_LOGGED_IN), p11Err)
 }
 
+func TestInvalidMaxSessions(t *testing.T) {
+	cfg, err := getConfig("config")
+	require.NoError(t, err)
+
+	cfg.MaxSessions = 1
+	_, err = Configure(cfg)
+	require.Error(t, err)
+}
+
 // randomBytes returns 32 random bytes.
 func randomBytes() []byte {
 	result := make([]byte, 32)


### PR DESCRIPTION
Return an error rather than panicking if `MaxSessions=1` in the config. Add doc comments indicating that `MaxSessions` cannot be 1.

Fixes #60 