### PR TITLE
makeKeyPair only based on CKA_ID

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -126,7 +126,7 @@ func (c *Context) makeKeyPair(session *pkcs11Session, privHandle *pkcs11.ObjectH
 	var pubHandle *pkcs11.ObjectHandle
 
 	// Find the public half which has a matching CKA_ID
-	pubHandle, err = findKey(session, id, label, uintPtr(pkcs11.CKO_PUBLIC_KEY), &keyType)
+	pubHandle, err = findKey(session, id, nil, uintPtr(pkcs11.CKO_PUBLIC_KEY), &keyType)
 	if err != nil {
 		p11Err, ok := err.(pkcs11.Error)
 

--- a/keys.go
+++ b/keys.go
@@ -126,7 +126,7 @@ func (c *Context) makeKeyPair(session *pkcs11Session, privHandle *pkcs11.ObjectH
 	var pubHandle *pkcs11.ObjectHandle
 
 	// Find the public half which has a matching CKA_ID
-	pubHandle, err = findKey(session, id, nil, uintPtr(pkcs11.CKO_PUBLIC_KEY), &keyType)
+	pubHandle, err = findKey(session, id, label, uintPtr(pkcs11.CKO_PUBLIC_KEY), &keyType)
 	if err != nil {
 		p11Err, ok := err.(pkcs11.Error)
 
@@ -154,6 +154,11 @@ func (c *Context) makeKeyPair(session *pkcs11Session, privHandle *pkcs11.ObjectH
 		} else {
 			return nil, err
 		}
+	}
+
+	if pubHandle == nil {
+		// Try harder to find a matching public key, based on CKA_ID alone
+		pubHandle, err = findKey(session, id, nil, uintPtr(pkcs11.CKO_PUBLIC_KEY), &keyType)
 	}
 
 	if pubHandle == nil {


### PR DESCRIPTION
On the HSM I am using, the private key has the label 'Private key for
Digital Signature', where the public key has the label 'Public key for
Digital Signature'. This means that the private and public key will
never match by label, as previously done. Matching by CKA_ID is
sufficient.