### PR TITLE
fix: issue casting byte slice to unsigned long type

### DIFF
--- a/common.go
+++ b/common.go
@@ -36,7 +36,23 @@ func ulongToBytes(n uint) []byte {
 }
 
 func bytesToUlong(bs []byte) (n uint) {
-	return *(*uint)(unsafe.Pointer(&bs[0])) // ugh
+	sliceSize := len(bs)
+	if sliceSize == 0 {
+		return 0
+	}
+
+	value := *(*uint)(unsafe.Pointer(&bs[0]))
+	if sliceSize > C.sizeof_ulong {
+		return value
+	}
+
+	// truncate the value to the # of bits present in the byte slice since
+	// the unsafe pointer will always grab/convert ULONG # of bytes
+	var mask uint
+	for i := 0; i < sliceSize; i++ {
+		mask |= 0xff << uint(i * 8)
+	}
+	return value & mask
 }
 
 func concat(slices ...[]byte) []byte {

--- a/common_test.go
+++ b/common_test.go
@@ -1,0 +1,36 @@
+package crypto11
+
+import (
+	"testing"
+)
+
+func TestULongMasking(t *testing.T) {
+	ulongData := uint(0x33221100ddccbbaa)
+	ulongSlice := ulongToBytes(ulongData)
+
+	// Build an slice that is longer than the size of a ulong
+	extraLongSlice := append(ulongSlice, ulongSlice...)
+
+	tests := []struct {
+		slice    []uint8
+		expected uint
+	}{
+		{ulongSlice[0:0], 0},
+		{ulongSlice[0:1], 0xaa},
+		{ulongSlice[0:2], 0xbbaa},
+		{ulongSlice[0:3], 0xccbbaa},
+		{ulongSlice[0:4], 0xddccbbaa},
+		{ulongSlice[0:5], 0x00ddccbbaa},
+		{ulongSlice[0:6], 0x1100ddccbbaa},
+		{ulongSlice[0:7], 0x221100ddccbbaa},
+		{ulongSlice[0:8], 0x33221100ddccbbaa},
+		{extraLongSlice, 0x33221100ddccbbaa},
+	}
+
+	for _, test := range tests {
+		got := bytesToUlong(test.slice)
+		if test.expected != got {
+			t.Errorf("conversion failed: 0x%X != 0x%X", test.expected, got)
+		}
+	}
+}


### PR DESCRIPTION
Fixed an issue where converting a byte slice that is smaller than
an unsigned long grabs adjacent memory data.

Fixes ThalesIgnite/crypto11#64