### PR TITLE
[RFC] ecdsa: Add support for ECDH1-DERIVE method

### DIFF
--- a/ecdsa.go
+++ b/ecdsa.go
@@ -261,6 +261,7 @@ func (c *Context) GenerateECDSAKeyPairWithAttributes(public, private AttributeSe
 			pkcs11.NewAttribute(pkcs11.CKA_SIGN, true),
 			pkcs11.NewAttribute(pkcs11.CKA_SENSITIVE, true),
 			pkcs11.NewAttribute(pkcs11.CKA_EXTRACTABLE, false),
+			pkcs11.NewAttribute(pkcs11.CKA_DERIVE, true),
 		})
 
 		mech := []*pkcs11.Mechanism{pkcs11.NewMechanism(pkcs11.CKM_ECDSA_KEY_PAIR_GEN, nil)}


### PR DESCRIPTION
Thanks for the excellent library. It was pretty easy for me to get go's httpclient to use this and softhsm for TLS.

Now I'm trying something slightly more complex. I'm working with something that does symmetric encryption using EC keys based on ecies. The library I'm using assumes access to the private key:

 https://github.com/ethereum/go-ethereum/blob/master/crypto/ecies/ecies.go#L120-L138

However, the operation done in that function is the equivalent of ECDH1-DERIVE. This PR is a proof-of-concept that allows me to do ecies decryption. I'm hoping you might be open to this change or something like it. 