### PR TITLE
feat(certificates): adding FindAllPairedCertificates()

### DIFF
--- a/certificates.go
+++ b/certificates.go
@@ -40,9 +40,11 @@ func findCertificate(session *pkcs11Session, id []byte, label []byte, serial *bi
 		return nil, err
 	}
 
-	cert, err = x509.ParseCertificate(rawCertificate)
-	if err != nil {
-		return nil, err
+	if rawCertificate != nil {
+		cert, err = x509.ParseCertificate(rawCertificate)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return cert, err

--- a/certificates.go
+++ b/certificates.go
@@ -22,6 +22,7 @@
 package crypto11
 
 import (
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/asn1"
 	"math/big"
@@ -29,6 +30,78 @@ import (
 	"github.com/miekg/pkcs11"
 	"github.com/pkg/errors"
 )
+
+// FindCertificate retrieves a previously imported certificate. Any combination of id, label
+// and serial can be provided. An error is return if all are nil.
+func findCertificate(session *pkcs11Session, id []byte, label []byte, serial *big.Int) (cert *x509.Certificate, err error) {
+
+	rawCertificate, err := findRawCertificate(session, id, label, serial)
+	if err != nil {
+		return nil, err
+	}
+
+	cert, err = x509.ParseCertificate(rawCertificate)
+	if err != nil {
+		return nil, err
+	}
+
+	return cert, err
+}
+
+func findRawCertificate(session *pkcs11Session, id []byte, label []byte, serial *big.Int) (rawCertificate []byte, err error) {
+	if id == nil && label == nil && serial == nil {
+		return nil, errors.New("id, label and serial cannot all be nil")
+	}
+
+	var template []*pkcs11.Attribute
+
+	if id != nil {
+		template = append(template, pkcs11.NewAttribute(pkcs11.CKA_ID, id))
+	}
+	if label != nil {
+		template = append(template, pkcs11.NewAttribute(pkcs11.CKA_LABEL, label))
+	}
+	if serial != nil {
+		derSerial, err := asn1.Marshal(serial)
+		if err != nil {
+			return nil, errors.WithMessage(err, "failed to encode serial")
+		}
+
+		template = append(template, pkcs11.NewAttribute(pkcs11.CKA_SERIAL_NUMBER, derSerial))
+	}
+
+	template = append(template, pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_CERTIFICATE))
+
+	if err = session.ctx.FindObjectsInit(session.handle, template); err != nil {
+		return nil, err
+	}
+	defer func() {
+		finalErr := session.ctx.FindObjectsFinal(session.handle)
+		if err == nil {
+			err = finalErr
+		}
+	}()
+
+	handles, _, err := session.ctx.FindObjects(session.handle, 1)
+	if err != nil {
+		return nil, err
+	}
+	if len(handles) == 0 {
+		return nil, nil
+	}
+
+	attributes := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_VALUE, 0),
+	}
+
+	if attributes, err = session.ctx.GetAttributeValue(session.handle, handles[0], attributes); err != nil {
+		return nil, err
+	}
+
+	rawCertificate = attributes[0].Value
+
+	return
+}
 
 // FindCertificate retrieves a previously imported certificate. Any combination of id, label
 // and serial can be provided. An error is return if all are nil.
@@ -40,60 +113,64 @@ func (c *Context) FindCertificate(id []byte, label []byte, serial *big.Int) (*x5
 
 	var cert *x509.Certificate
 	err := c.withSession(func(session *pkcs11Session) (err error) {
-		if id == nil && label == nil && serial == nil {
-			return errors.New("id, label and serial cannot all be nil")
-		}
-
-		var template []*pkcs11.Attribute
-
-		if id != nil {
-			template = append(template, pkcs11.NewAttribute(pkcs11.CKA_ID, id))
-		}
-		if label != nil {
-			template = append(template, pkcs11.NewAttribute(pkcs11.CKA_LABEL, label))
-		}
-		if serial != nil {
-			derSerial, err := asn1.Marshal(serial)
-			if err != nil {
-				return errors.WithMessage(err, "failed to encode serial")
-			}
-
-			template = append(template, pkcs11.NewAttribute(pkcs11.CKA_SERIAL_NUMBER, derSerial))
-		}
-
-		template = append(template, pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_CERTIFICATE))
-
-		if err = session.ctx.FindObjectsInit(session.handle, template); err != nil {
-			return err
-		}
-		defer func() {
-			finalErr := session.ctx.FindObjectsFinal(session.handle)
-			if err == nil {
-				err = finalErr
-			}
-		}()
-
-		handles, _, err := session.ctx.FindObjects(session.handle, 1)
-		if err != nil {
-			return err
-		}
-		if len(handles) == 0 {
-			return nil
-		}
-
-		attributes := []*pkcs11.Attribute{
-			pkcs11.NewAttribute(pkcs11.CKA_VALUE, 0),
-		}
-
-		if attributes, err = session.ctx.GetAttributeValue(session.handle, handles[0], attributes); err != nil {
-			return err
-		}
-
-		cert, err = x509.ParseCertificate(attributes[0].Value)
+		cert, err = findCertificate(session, id, label, serial)
 		return err
 	})
 
 	return cert, err
+}
+
+func (c *Context) FindAllPairedCertificates() (certificates []tls.Certificate, err error) {
+	if c.closed.Get() {
+		return nil, errClosed
+	}
+
+	err = c.withSession(func(session *pkcs11Session) error {
+		// Add the private key class to the template to find the private half
+		privAttributes := AttributeSet{}
+		err = privAttributes.Set(CkaClass, pkcs11.CKO_PRIVATE_KEY)
+		if err != nil {
+			return err
+		}
+
+		privHandles, err := findKeysWithAttributes(session, privAttributes.ToSlice())
+		if err != nil {
+			return err
+		}
+
+		for _, privHandle := range privHandles {
+
+			privateKey, certificate, err := c.makeKeyPair(session, &privHandle)
+
+			if err == errNoCkaId || err == errNoPublicHalf {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			if certificate == nil {
+				continue
+			}
+
+			tlsCert := tls.Certificate{
+				Leaf:       certificate,
+				PrivateKey: privateKey,
+			}
+
+			tlsCert.Certificate = append(tlsCert.Certificate, certificate.Raw)
+			certificates = append(certificates, tlsCert)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return
 }
 
 // ImportCertificate imports a certificate onto the token. The id parameter is used to

--- a/keys.go
+++ b/keys.go
@@ -23,7 +23,7 @@ package crypto11
 
 import (
 	"crypto"
-
+	"crypto/x509"
 	"github.com/miekg/pkcs11"
 	"github.com/pkg/errors"
 )
@@ -105,14 +105,14 @@ func findKey(session *pkcs11Session, id []byte, label []byte, keyclass *uint, ke
 
 // Takes a handles to the private half of a keypair, locates the public half with the matching CKA_ID and CKA_LABEL
 // values and constructs a keypair object from them both.
-func (c *Context) makeKeyPair(session *pkcs11Session, privHandle *pkcs11.ObjectHandle) (signer Signer, err error) {
+func (c *Context) makeKeyPair(session *pkcs11Session, privHandle *pkcs11.ObjectHandle) (signer Signer, certificate *x509.Certificate, err error) {
 	attributes := []*pkcs11.Attribute{
 		pkcs11.NewAttribute(pkcs11.CKA_ID, nil),
 		pkcs11.NewAttribute(pkcs11.CKA_LABEL, nil),
 		pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, 0),
 	}
 	if attributes, err = session.ctx.GetAttributeValue(session.handle, *privHandle, attributes); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	id := attributes[0].Value
 	label := attributes[1].Value
@@ -120,7 +120,7 @@ func (c *Context) makeKeyPair(session *pkcs11Session, privHandle *pkcs11.ObjectH
 
 	// Ensure the private key actually has a non-empty CKA_ID to match on
 	if id == nil || len(id) == 0 {
-		return nil, errNoCkaId
+		return nil, nil, errNoCkaId
 	}
 
 	var pubHandle *pkcs11.ObjectHandle
@@ -137,14 +137,14 @@ func (c *Context) makeKeyPair(session *pkcs11Session, privHandle *pkcs11.ObjectH
 
 			pubHandles, err := findKeys(session, id, nil, uintPtr(pkcs11.CKO_PUBLIC_KEY), &keyType)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 
 			for _, handle := range pubHandles {
 				template := []*pkcs11.Attribute{pkcs11.NewAttribute(pkcs11.CKA_LABEL, nil)}
 				template, err = session.ctx.GetAttributeValue(session.handle, handle, template)
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
 				if len(template[0].Value) == 0 {
 					pubHandle = &handle
@@ -152,7 +152,7 @@ func (c *Context) makeKeyPair(session *pkcs11Session, privHandle *pkcs11.ObjectH
 				}
 			}
 		} else {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
@@ -161,57 +161,63 @@ func (c *Context) makeKeyPair(session *pkcs11Session, privHandle *pkcs11.ObjectH
 		pubHandle, err = findKey(session, id, nil, uintPtr(pkcs11.CKO_PUBLIC_KEY), &keyType)
 	}
 
-	if pubHandle == nil {
-		// We can't return a Signer if we don't have private and public key. Treat it as an error.
-		return nil, errNoPublicHalf
+	resultPkcs11PrivateKey := pkcs11PrivateKey{
+		pkcs11Object: pkcs11Object{
+			handle:  *privHandle,
+			context: c,
+		},
 	}
 
 	var pub crypto.PublicKey
+	certificate, _ = findCertificate(session, id, nil, nil)
+	if certificate != nil && pubHandle == nil {
+		pub = certificate.PublicKey
+	}
+
+	if pub == nil && pubHandle == nil {
+		// We can't return a Signer if we don't have private and public key. Treat it as an error.
+		return nil, nil, errNoPublicHalf
+	}
+
 	switch keyType {
 	case pkcs11.CKK_DSA:
-		if pub, err = exportDSAPublicKey(session, *pubHandle); err != nil {
-			return nil, err
+		result := &pkcs11PrivateKeyDSA{pkcs11PrivateKey: resultPkcs11PrivateKey}
+		if pubHandle != nil {
+			if pub, err = exportDSAPublicKey(session, *pubHandle); err != nil {
+				return nil, nil, err
+			}
+			result.pkcs11PrivateKey.pubKeyHandle = *pubHandle
 		}
-		return &pkcs11PrivateKeyDSA{
-			pkcs11PrivateKey: pkcs11PrivateKey{
-				pkcs11Object: pkcs11Object{
-					handle:  *privHandle,
-					context: c,
-				},
-				pubKeyHandle: *pubHandle,
-				pubKey:       pub,
-			}}, nil
+
+		result.pkcs11PrivateKey.pubKey = pub
+		return result, certificate, nil
 
 	case pkcs11.CKK_RSA:
-		if pub, err = exportRSAPublicKey(session, *pubHandle); err != nil {
-			return nil, err
+		result := &pkcs11PrivateKeyRSA{pkcs11PrivateKey: resultPkcs11PrivateKey}
+		if pubHandle != nil {
+			if pub, err = exportRSAPublicKey(session, *pubHandle); err != nil {
+				return nil, nil, err
+			}
+			result.pkcs11PrivateKey.pubKeyHandle = *pubHandle
 		}
-		return &pkcs11PrivateKeyRSA{
-			pkcs11PrivateKey: pkcs11PrivateKey{
-				pkcs11Object: pkcs11Object{
-					handle:  *privHandle,
-					context: c,
-				},
-				pubKeyHandle: *pubHandle,
-				pubKey:       pub,
-			}}, nil
+
+		result.pkcs11PrivateKey.pubKey = pub
+		return result, certificate, nil
 
 	case pkcs11.CKK_ECDSA:
-		if pub, err = exportECDSAPublicKey(session, *pubHandle); err != nil {
-			return nil, err
+		result := &pkcs11PrivateKeyECDSA{pkcs11PrivateKey: resultPkcs11PrivateKey}
+		if pubHandle != nil {
+			if pub, err = exportECDSAPublicKey(session, *pubHandle); err != nil {
+				return nil, nil, err
+			}
+			result.pkcs11PrivateKey.pubKeyHandle = *pubHandle
 		}
-		return &pkcs11PrivateKeyECDSA{
-			pkcs11PrivateKey: pkcs11PrivateKey{
-				pkcs11Object: pkcs11Object{
-					handle:  *privHandle,
-					context: c,
-				},
-				pubKeyHandle: *pubHandle,
-				pubKey:       pub,
-			}}, nil
+
+		result.pkcs11PrivateKey.pubKey = pub
+		return result, certificate, nil
 
 	default:
-		return nil, errors.Errorf("unsupported key type: %X", keyType)
+		return nil, nil, errors.Errorf("unsupported key type: %X", keyType)
 	}
 }
 
@@ -327,7 +333,7 @@ func (c *Context) FindKeyPairsWithAttributes(attributes AttributeSet) (signer []
 		}
 
 		for _, privHandle := range privHandles {
-			k, err := c.makeKeyPair(session, &privHandle)
+			k, _, err := c.makeKeyPair(session, &privHandle)
 
 			if err == errNoCkaId || err == errNoPublicHalf {
 				continue


### PR DESCRIPTION
closes #77

```
package main

import (
	"crypto/tls"
	"fmt"
	"io/ioutil"
	"log"
	"net/http"
        "github.com/ThalesIgnite/crypto11"
)

func main() {
	config := crypto11.Config{
		Path: "C:\\Windows\\System32\\vendor-pkcs11.dll",
		TokenSerial: "123456789456123",
		Pin: "123456",
	}

	context, err := crypto11.Configure(&config)
	if err != nil{
		fmt.Println(err);
		return
	}

	certificates, err := context.FindAllPairedCertificates()
	if err != nil{
		fmt.Println(err);
		return
	}

	fmt.Println("total certificates: ", len(certificates))

	cert := certificates[0]
	client := &http.Client{
		Transport: &http.Transport{
			TLSClientConfig: &tls.Config{
				Certificates: []tls.Certificate{cert},
				Renegotiation:      tls.RenegotiateOnceAsClient,
			},
		},
	}

	req, err := http.NewRequest("GET", "https://server.cryptomix.com:443/secure/", nil)
	if err != nil {
		log.Fatalln(err)
	}

	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.135 Safari/537.36")

	resp, err := client.Do(req)
	if err != nil {
		log.Fatalln(err)
	}

	if resp == nil{
		return
	}

	fmt.Println("status code: ", resp.StatusCode)

	if resp.StatusCode == http.StatusOK {
		bodyBytes, err := ioutil.ReadAll(resp.Body)
		if err != nil {
			log.Fatal(err)
		}
		bodyString := string(bodyBytes)
		fmt.Println(bodyString)
	}
}
```

go.mod

```
module mytestmodule

go 1.13

require github.com/ThalesIgnite/crypto11 v1.2.3

replace github.com/ThalesIgnite/crypto11 => github.com/jossef/crypto11 v1.2.4-0.20201013070430-349b14f33a60

```