### PR TITLE
Upgrade miekg/pkcs11 from v1.0.3 to v1.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ThalesIgnite/crypto11
 go 1.13
 
 require (
-	github.com/miekg/pkcs11 v1.0.3-0.20190429190417-a667d056470f
+	github.com/miekg/pkcs11 v1.1.1
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
 	github.com/thales-e-security/pool v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/miekg/pkcs11 v1.0.3-0.20190429190417-a667d056470f h1:eVB9ELsoq5ouItQBr5Tj334bhPJG/MX+m7rTchmzVUQ=
-github.com/miekg/pkcs11 v1.0.3-0.20190429190417-a667d056470f/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
+github.com/miekg/pkcs11 v1.1.1 h1:Ugu9pdy6vAYku5DEpVWVFPYnzV+bxB+iRdbuFSu7TvU=
+github.com/miekg/pkcs11 v1.1.1/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Currently, the ThalesIgnite/crypto11 library does not build on OpenBSD:

```
$ go test .
# github.com/miekg/pkcs11
ld: error: unable to find library -ldl
cc: error: linker command failed with exit code 1 (use -v to see invocation)
FAIL	github.com/ThalesIgnite/crypto11 [build failed]
FAIL
```

This PR upgrades the miekg/pkcs11 component to a version that compiles cleanly on OpenBSD. Here are the functional PR's included in the miekg/pkcs11 upgrade from v1.0.3:

* https://github.com/miekg/pkcs11/pull/124
* https://github.com/miekg/pkcs11/pull/133
* https://github.com/miekg/pkcs11/pull/137
* https://github.com/miekg/pkcs11/pull/140
* https://github.com/miekg/pkcs11/pull/143
* https://github.com/miekg/pkcs11/pull/150

For a more specific diff , see https://github.com/miekg/pkcs11/compare/v1.0.3...v1.1.1