### PR TITLE
Support to open serial only sessions

### DIFF
--- a/crypto11.go
+++ b/crypto11.go
@@ -265,6 +265,8 @@ type Config struct {
 	GCMIVLength int
 
 	GCMIVFromHSMControl GCMIVFromHSMConfig
+
+	SerialSessionOnly bool
 }
 
 type GCMIVFromHSMConfig struct {
@@ -362,7 +364,12 @@ func Configure(config *Config) (*Context, error) {
 
 	// Create a long-term session and log it in (if supported). This session won't be used by callers, instead it is
 	// used to keep a connection alive to the token to ensure object handles and the log in status remain accessible.
-	instance.persistentSession, err = instance.ctx.OpenSession(instance.slot, pkcs11.CKF_SERIAL_SESSION|pkcs11.CKF_RW_SESSION)
+	flags := uint(pkcs11.CKF_SERIAL_SESSION)
+	if !config.SerialSessionOnly {
+		flags = flags | pkcs11.CKF_RW_SESSION
+	}
+
+	instance.persistentSession, err = instance.ctx.OpenSession(instance.slot, flags)
 	if err != nil {
 		_ = instance.ctx.Finalize()
 		instance.ctx.Destroy()

--- a/sessions.go
+++ b/sessions.go
@@ -80,7 +80,13 @@ func (c *Context) getSession() (*pkcs11Session, error) {
 
 // resourcePoolFactoryFunc is called by the resource pool when a new session is needed.
 func (c *Context) resourcePoolFactoryFunc() (pool.Resource, error) {
-	session, err := c.ctx.OpenSession(c.slot, pkcs11.CKF_SERIAL_SESSION|pkcs11.CKF_RW_SESSION)
+	flags := uint(pkcs11.CKF_SERIAL_SESSION)
+
+	if !c.cfg.SerialSessionOnly {
+		flags = flags | pkcs11.CKF_RW_SESSION
+	}
+
+	session, err := c.ctx.OpenSession(c.slot, flags)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Our PKCS#11 devices only support serial only sessions hence this library is failing with the following error:
```
error: PKCS11 function C_OpenSession failed: rv = CKR_TOKEN_WRITE_PROTECTED (0xe2)
```

This change is to introduce an optional configuration to allow initialize P11 context with serial only session.


#### Types of Changes ####

<!-- What types of changes does your code introduce ? Bugfix, New Feature, Breaking Change, etc -->
* New Feature & Backward-Compatible

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

We tested with our PKCS#11 devices.

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

We tested with our PKCS#11 devices.

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Support serial only sessions.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
