### PR TITLE
fix: underlying library context is reused through reference counting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+dist: xenial
+
+language: go
+
+go:
+  - "1.23.x"
+
+# Xenial comes with v2.0.0 SoftHSM2, which seems to have issues with ECDSA
+
+# code points
+
+addons:
+  apt:
+    sources:
+      - sourceline: "ppa:pkg-opendnssec/ppa"
+
+    packages:
+      - softhsm2
+
+env:
+  - GO111MODULE=on
+
+script:
+  - echo directories.tokendir = `pwd`/tokens > softhsm2.conf
+  - echo objecstore.backend = file >> softhsm2.conf
+  - cat softhsm2.conf
+  - mkdir tokens
+  - export SOFTHSM2_CONF=`pwd`/softhsm2.conf
+  - softhsm2-util --init-token --slot 0 --label token1 --so-pin sopassword --pin password
+  - softhsm2-util --init-token --slot 1 --label token2 --so-pin sopassword --pin password
+  - go test -mod readonly -v -bench .

--- a/common.go
+++ b/common.go
@@ -50,7 +50,7 @@ func bytesToUlong(bs []byte) (n uint) {
 	// the unsafe pointer will always grab/convert ULONG # of bytes
 	var mask uint
 	for i := 0; i < sliceSize; i++ {
-		mask |= 0xff << uint(i * 8)
+		mask |= 0xff << uint(i*8)
 	}
 	return value & mask
 }

--- a/common_test.go
+++ b/common_test.go
@@ -3,11 +3,10 @@ package crypto11
 import (
 	"crypto/rand"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
-
-
 
 func skipIfMechUnsupported(t *testing.T, ctx *Context, wantMech uint) {
 	mechs, err := ctx.ctx.GetMechanismList(ctx.slot)
@@ -65,7 +64,7 @@ func makeIV(cipher *SymmetricCipher) ([]byte, error) {
 	return iv, err
 }
 
-func createKey(ctx *Context, keyLabel string, keySize int, KeyType int)(key *SecretKey, err error){
+func createKey(ctx *Context, keyLabel string, keySize int, KeyType int) (key *SecretKey, err error) {
 	id := make([]byte, 16)
 	rand.Read(id)
 	if key, err = ctx.GenerateSecretKeyWithLabel(id, []byte(keyLabel), keySize, Ciphers[KeyType]); err != nil {
@@ -81,9 +80,8 @@ func findKeyOrCreate(ctx *Context, keyLabel string, keyTypeCreation int, keySize
 	if key, err = ctx.FindKey(nil, []byte(keyLabel)); key == nil {
 		found = false
 		key, err = createKey(ctx, keyLabel, keySizeCreation, keyTypeCreation)
-	} else{
+	} else {
 		found = true
 	}
 	return key, found, err
 }
-

--- a/crypto11.go
+++ b/crypto11.go
@@ -21,7 +21,7 @@
 
 // Package crypto11 enables access to cryptographic keys from PKCS#11 using Go crypto API.
 //
-// Configuration
+// # Configuration
 //
 // PKCS#11 tokens are accessed via Context objects. Each Context connects to one token.
 //
@@ -29,7 +29,7 @@
 // In the latter case, the file should contain a JSON representation of
 // a Config.
 //
-// Key Generation and Usage
+// # Key Generation and Usage
 //
 // There is support for generating DSA, RSA and ECDSA keys. These keys
 // can be found later using FindKeyPair. All three key types implement
@@ -42,7 +42,7 @@
 // Symmetric keys can also be generated. These are found later using FindKey.
 // See the documentation for SecretKey for further information.
 //
-// Sessions and concurrency
+// # Sessions and concurrency
 //
 // Note that PKCS#11 session handles must not be used concurrently
 // from multiple threads. Consumers of the Signer interface know
@@ -74,7 +74,7 @@
 // a default maximum is used (see DefaultMaxSessions). In every case the maximum
 // supported sessions as reported by the token is obeyed.
 //
-// Limitations
+// # Limitations
 //
 // The PKCS1v15DecryptOptions SessionKeyLen field is not implemented
 // and an error is returned if it is nonzero.
@@ -171,7 +171,7 @@ type Context struct {
 	// Atomic fields must be at top (according to the package owners)
 	closed pool.AtomicBool
 
-	ctx *pkcs11.Ctx
+	ctx moduleCtx
 	cfg *Config
 
 	token *pkcs11.TokenInfo
@@ -302,10 +302,83 @@ type GCMIVFromHSMConfig struct {
 	SupplyIvForHSMGCMDecrypt bool
 }
 
-// refCount counts the number of contexts using a particular P11 library. It must not be read or modified
+// refCount holds the different contexts using a particular P11 library. It must not be read or modified
 // without holding refCountMutex.
-var refCount = map[string]int{}
+var refCount = map[string]moduleSlot{}
 var refCountMutex = sync.Mutex{}
+
+type moduleSlot struct {
+	module   moduleCtx
+	refCount int
+}
+
+func openModule(path string) (moduleCtx, error) {
+	refCountMutex.Lock()
+	defer refCountMutex.Unlock()
+
+	if slot, ok := refCount[path]; ok {
+		refCnt := slot.refCount
+		refCount[path] = moduleSlot{
+			module:   slot.module,
+			refCount: refCnt + 1,
+		}
+
+		return slot.module, nil
+	}
+
+	ctx := pkcs11.New(path)
+	if ctx == nil {
+		return moduleCtx{}, errors.New("failed to open module")
+	}
+
+	if err := ctx.Initialize(); err != nil {
+		ctx.Destroy()
+		return moduleCtx{}, fmt.Errorf("failed to initialize module: %w", err)
+	}
+
+	module := moduleCtx{ctx}
+	refCount[path] = moduleSlot{
+		module:   module,
+		refCount: 1,
+	}
+	return module, nil
+}
+
+type moduleCtx struct {
+	*pkcs11.Ctx
+}
+
+func (m moduleCtx) Close() {
+	refCountMutex.Lock()
+	defer refCountMutex.Unlock()
+
+	var path string
+	var slot moduleSlot
+	for p, s := range refCount {
+		if s.module == m {
+			path = p
+			slot = s
+			break
+		}
+	}
+	if path == "" {
+		return
+	}
+	if slot.refCount < 1 {
+		panic("invalid reference count for PKCS#11 library")
+	}
+
+	if slot.refCount == 1 {
+		_ = m.Finalize()
+		m.Destroy()
+		delete(refCount, path)
+	} else {
+		refCount[path] = moduleSlot{
+			module:   slot.module,
+			refCount: slot.refCount - 1,
+		}
+	}
+}
 
 // Configure creates a new Context based on the supplied PKCS#11 configuration.
 func Configure(config *Config) (*Context, error) {
@@ -341,38 +414,24 @@ func Configure(config *Config) (*Context, error) {
 		config.GCMIVLength = DefaultGCMIVLength
 	}
 
+	modCtx, err := openModule(config.Path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create module context: %w", err)
+	}
 	instance := &Context{
 		cfg: config,
-		ctx: pkcs11.New(config.Path),
+		ctx: modCtx,
 	}
 
-	if instance.ctx == nil {
-		return nil, errors.New("could not open PKCS#11")
-	}
-
-	// Check how many contexts are currently using this library
-	refCountMutex.Lock()
-	defer refCountMutex.Unlock()
-	numExistingContexts := refCount[config.Path]
-
-	// Only Initialize if we are the first Context using the library
-	if numExistingContexts == 0 {
-		if err := instance.ctx.Initialize(); err != nil {
-			instance.ctx.Destroy()
-			return nil, errors.WithMessage(err, "failed to initialize PKCS#11 library")
-		}
-	}
 	slots, err := instance.ctx.GetSlotList(true)
 	if err != nil {
-		_ = instance.ctx.Finalize()
-		instance.ctx.Destroy()
+		instance.ctx.Close()
 		return nil, errors.WithMessage(err, "failed to list PKCS#11 slots")
 	}
 
 	instance.slot, instance.token, err = instance.findToken(slots, config.TokenSerial, config.TokenLabel, config.SlotNumber)
 	if err != nil {
-		_ = instance.ctx.Finalize()
-		instance.ctx.Destroy()
+		instance.ctx.Close()
 		return nil, err
 	}
 
@@ -390,8 +449,7 @@ func Configure(config *Config) (*Context, error) {
 	// used to keep a connection alive to the token to ensure object handles and the log in status remain accessible.
 	instance.persistentSession, err = instance.ctx.OpenSession(instance.slot, pkcs11.CKF_SERIAL_SESSION|pkcs11.CKF_RW_SESSION)
 	if err != nil {
-		_ = instance.ctx.Finalize()
-		instance.ctx.Destroy()
+		instance.ctx.Close()
 		return nil, errors.WithMessagef(err, "failed to create long term session")
 	}
 
@@ -408,15 +466,11 @@ func Configure(config *Config) (*Context, error) {
 			pErr, isP11Error := err.(pkcs11.Error)
 
 			if !isP11Error || pErr != pkcs11.CKR_USER_ALREADY_LOGGED_IN {
-				_ = instance.ctx.Finalize()
-				instance.ctx.Destroy()
+				instance.ctx.Close()
 				return nil, errors.WithMessagef(err, "failed to log into long term session")
 			}
 		}
 	}
-
-	// Increment the reference count
-	refCount[config.Path] = numExistingContexts + 1
 
 	return instance, nil
 }
@@ -476,11 +530,6 @@ func loadConfigFromFile(configLocation string) (*Config, error) {
 // Close releases resources used by the Context and unloads the PKCS #11 library if there are no other
 // Contexts using it. Close blocks until existing operations have finished. A closed Context cannot be reused.
 func (c *Context) Close() error {
-
-	// Take lock on the reference count
-	refCountMutex.Lock()
-	defer refCountMutex.Unlock()
-
 	c.closed.Set(true)
 
 	// Block until all resources returned to pool
@@ -490,22 +539,7 @@ func (c *Context) Close() error {
 	// since we plan to kill our collection to the library anyway.
 	_ = c.ctx.CloseSession(c.persistentSession)
 
-	count, found := refCount[c.cfg.Path]
-	if !found || count == 0 {
-		// We have somehow lost track of reference counts, this is very bad
-		panic("invalid reference count for PKCS#11 library")
-	}
+	c.ctx.Close()
 
-	refCount[c.cfg.Path] = count - 1
-
-	// If we were the last Context, finalize the library
-	if count == 1 {
-		err := c.ctx.Finalize()
-		if err != nil {
-			return err
-		}
-	}
-
-	c.ctx.Destroy()
 	return nil
 }

--- a/crypto11.go
+++ b/crypto11.go
@@ -302,28 +302,30 @@ type GCMIVFromHSMConfig struct {
 	SupplyIvForHSMGCMDecrypt bool
 }
 
-// refCount holds the different contexts using a particular P11 library. It must not be read or modified
-// without holding refCountMutex.
-var refCount = map[string]moduleSlot{}
-var refCountMutex = sync.Mutex{}
+// moduleReferences holds the different contexts using a particular P11 library. It must not be read or modified
+// without holding moduleReferencesMutex.
+var moduleReferences = map[string]moduleRef{}
+var moduleReferencesMutex = sync.Mutex{}
 
-type moduleSlot struct {
-	module   moduleCtx
+// Specific moduleRef with its context and reference count.
+type moduleRef struct {
+	ctx      moduleCtx
 	refCount int
 }
 
+// Creates new context or returns an existing one if one has been already created.
 func openModule(path string) (moduleCtx, error) {
-	refCountMutex.Lock()
-	defer refCountMutex.Unlock()
+	moduleReferencesMutex.Lock()
+	defer moduleReferencesMutex.Unlock()
 
-	if slot, ok := refCount[path]; ok {
-		refCnt := slot.refCount
-		refCount[path] = moduleSlot{
-			module:   slot.module,
-			refCount: refCnt + 1,
+	if mod, ok := moduleReferences[path]; ok {
+		// Module with given path has been already initialized.
+		moduleReferences[path] = moduleRef{
+			ctx:      mod.ctx,
+			refCount: mod.refCount + 1,
 		}
 
-		return slot.module, nil
+		return mod.ctx, nil
 	}
 
 	ctx := pkcs11.New(path)
@@ -336,46 +338,52 @@ func openModule(path string) (moduleCtx, error) {
 		return moduleCtx{}, fmt.Errorf("failed to initialize module: %w", err)
 	}
 
-	module := moduleCtx{ctx}
-	refCount[path] = moduleSlot{
-		module:   module,
+	modCtx := moduleCtx{ctx}
+	moduleReferences[path] = moduleRef{
+		ctx:      modCtx,
 		refCount: 1,
 	}
-	return module, nil
+	return modCtx, nil
 }
 
+// Context to a specific module. Users of the module all share the same context.
 type moduleCtx struct {
 	*pkcs11.Ctx
 }
 
-func (m moduleCtx) Close() {
-	refCountMutex.Lock()
-	defer refCountMutex.Unlock()
+// Close drops reference to its associated module and does cleanup if it is the last reference.
+func (mc moduleCtx) Close() {
+	moduleReferencesMutex.Lock()
+	defer moduleReferencesMutex.Unlock()
 
 	var path string
-	var slot moduleSlot
-	for p, s := range refCount {
-		if s.module == m {
+	var mod moduleRef
+	for p, ref := range moduleReferences {
+		if ref.ctx == mc {
 			path = p
-			slot = s
+			mod = ref
 			break
 		}
 	}
 	if path == "" {
-		return
+		// Instance has already been destroyed even though we are holding a reference.
+		panic("referenced module not found")
 	}
-	if slot.refCount < 1 {
+	if mod.refCount < 1 {
+		// Reference count has lost count of the number of actual references.
 		panic("invalid reference count for PKCS#11 library")
 	}
 
-	if slot.refCount == 1 {
-		_ = m.Finalize()
-		m.Destroy()
-		delete(refCount, path)
+	if mod.refCount == 1 {
+		// Do cleanup as last reference.
+		_ = mc.Finalize()
+		mc.Destroy()
+		delete(moduleReferences, path)
 	} else {
-		refCount[path] = moduleSlot{
-			module:   slot.module,
-			refCount: slot.refCount - 1,
+		// Decrement reference count.
+		moduleReferences[path] = moduleRef{
+			ctx:      mod.ctx,
+			refCount: mod.refCount - 1,
 		}
 	}
 }
@@ -539,6 +547,8 @@ func (c *Context) Close() error {
 	// since we plan to kill our collection to the library anyway.
 	_ = c.ctx.CloseSession(c.persistentSession)
 
+	// Drop reference to the held context. May destroy the module instance
+	// if this is the last reference to it.
 	c.ctx.Close()
 
 	return nil

--- a/crypto11_test.go
+++ b/crypto11_test.go
@@ -287,7 +287,7 @@ func TestInvalidPinDoesntDestroyLibrary(t *testing.T) {
 	cfg_wrong_pin, err := getConfig("config")
 	require.NoError(t, err)
 	cfg_wrong_pin.Pin = "this_should_be_wrong_pin"
-	cfg.TokenLabel = "token2"
+	cfg_wrong_pin.TokenLabel = "token2"
 
 	// Configure context with valid configuration.
 	ctx1, err := Configure(cfg)

--- a/crypto11_test.go
+++ b/crypto11_test.go
@@ -284,17 +284,17 @@ func TestInvalidPinDoesntDestroyLibrary(t *testing.T) {
 	require.NoError(t, err)
 	cfg.TokenLabel = "token1"
 
-	cfg_wrong_pin, err := getConfig("config")
+	cfgWrongPin, err := getConfig("config")
 	require.NoError(t, err)
-	cfg_wrong_pin.Pin = "this_should_be_wrong_pin"
-	cfg_wrong_pin.TokenLabel = "token2"
+	cfgWrongPin.Pin = "this_should_be_wrong_pin"
+	cfgWrongPin.TokenLabel = "token2"
 
 	// Configure context with valid configuration.
 	ctx1, err := Configure(cfg)
 	require.NoError(t, err)
 
 	// Try to configure context with invalid pin in configuration.
-	_, err = Configure(cfg_wrong_pin)
+	_, err = Configure(cfgWrongPin)
 	require.EqualError(t, err, "failed to log into long term session: pkcs11: 0xA0: CKR_PIN_INCORRECT")
 
 	// Existing context should continue to work.

--- a/hmac_test.go
+++ b/hmac_test.go
@@ -62,11 +62,10 @@ func testHmac(t *testing.T, ctx *Context, keyLabel string, keytype int, mech int
 	key, found, err := findKeyOrCreate(ctx, keyLabel, keytype, 256)
 	require.NoError(t, err)
 	require.NotNil(t, key)
-	if ! found {
+	if !found {
 		// so it was created
 		defer key.Delete()
 	}
-
 
 	t.Run("Short", func(t *testing.T) {
 		input := []byte("a short string")

--- a/sessions.go
+++ b/sessions.go
@@ -84,5 +84,5 @@ func (c *Context) resourcePoolFactoryFunc() (pool.Resource, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &pkcs11Session{c.ctx, session}, nil
+	return &pkcs11Session{c.ctx.Ctx, session}, nil
 }


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Fix for #113. Sorry for the unnecessary formatting changes.

#### Types of Changes ####

<!-- What types of changes does your code introduce ? Bugfix, New Feature, Breaking Change, etc -->

Fix so that references to library context are shared and not destroyed until the last library user is destroyed.

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Verify that reproduce steps in #113 do not cause CKR_CRYPTOKI_NOT_INITIALIZED error and library works as expected on multiple slots.

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

I have verified that this fix works on my application, but I have not added unit tests. However, I'm ready to accept suggestions.

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#113 

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

