### PR TITLE
Add EC key support in crypto module compatible with ECDSA/ECDH

### DIFF
--- a/common.go
+++ b/common.go
@@ -35,6 +35,10 @@ func ulongToBytes(n uint) []byte {
 	return C.GoBytes(unsafe.Pointer(&n), C.sizeof_ulong) // ugh!
 }
 
+func bytesToBool(bs []byte) bool {
+	return len(bs) > 0 && bs[0] != 0
+}
+
 func bytesToUlong(bs []byte) (n uint) {
 	sliceSize := len(bs)
 	if sliceSize == 0 {

--- a/crypto11.go
+++ b/crypto11.go
@@ -191,6 +191,17 @@ type Signer interface {
 	Delete() error
 }
 
+// Deriver is a PKCS#11 key that can be used to derive new keys.
+type Deriver interface {
+	// Derive derives a new key from the current key, using the supplied template and options. The template is used to specify
+	// attributes of the derived key, and the options are used to specify any parameters needed for the derivation.
+	Derive(template AttributeSet, cipher *SymmetricCipher, opts any) (*SecretKey, error)
+
+	Public() crypto.PublicKey
+
+	Delete() error
+}
+
 // SignerDecrypter is a PKCS#11 key implements crypto.Signer and crypto.Decrypter.
 type SignerDecrypter interface {
 	Signer

--- a/ec.go
+++ b/ec.go
@@ -404,7 +404,7 @@ func (key *pkcs11PrivateKeyEC) Derive(template AttributeSet, cipher *SymmetricCi
 		}
 	}
 
-	return nil, deriveErr
+	return nil, errors.New("failed to derive ECDH secret key with any of the provided symmetric cipher generation parameters")
 }
 
 var wellKnownEcdh1KDFKeySize = map[uint]int{}

--- a/ec.go
+++ b/ec.go
@@ -112,7 +112,7 @@ func exportECPublicKey(session *pkcs11Session, pubHandle pkcs11.ObjectHandle) (c
 	template := []*pkcs11.Attribute{
 		pkcs11.NewAttribute(pkcs11.CKA_EC_PARAMS, nil),
 		pkcs11.NewAttribute(pkcs11.CKA_EC_POINT, nil),
-		pkcs11.NewAttribute(pkcs11.CKA_DERIVE, nil),
+		pkcs11.NewAttribute(pkcs11.CKA_VERIFY, nil),
 	}
 	if attributes, err = session.ctx.GetAttributeValue(session.handle, pubHandle, template); err != nil {
 		return nil, err
@@ -122,16 +122,11 @@ func exportECPublicKey(session *pkcs11Session, pubHandle pkcs11.ObjectHandle) (c
 		return nil, errors.Errorf("expected %d attributes but got %d", len(template), len(attributes))
 	}
 
-	params, point, isDerive := attributes[0], attributes[1], attributes[2]
+	params, point, isVerify := attributes[0], attributes[1], attributes[2]
 
-	if bytesToBool(isDerive.Value) {
-		curve, err := unmarshalEcdhParams(params.Value)
-		if err != nil {
-			return nil, err
-		}
-
-		return unmarshalEcdhPoint(point.Value, curve)
-	} else {
+	// If the key is a verify key, we assume it's an ECDSA public key. Otherwise, we assume it's an ECDH public key.
+	// AWS CloudHSM can not set CKA_DERIVE on ECDH public keys, so we can't rely on that attribute to determine the key type.
+	if bytesToBool(isVerify.Value) {
 		var pub ecdsa.PublicKey
 		if pub.Curve, err = unmarshalEcParams(params.Value); err != nil {
 			return nil, err
@@ -140,8 +135,14 @@ func exportECPublicKey(session *pkcs11Session, pubHandle pkcs11.ObjectHandle) (c
 			return nil, err
 		}
 		return &pub, nil
-	}
+	} else {
+		curve, err := unmarshalEcdhParams(params.Value)
+		if err != nil {
+			return nil, err
+		}
 
+		return unmarshalEcdhPoint(point.Value, curve)
+	}
 }
 
 // GenerateECKeyPair creates a EC key pair on the token using curve c. The id parameter is used to
@@ -186,6 +187,12 @@ func (c *Context) GenerateECKeyPairWithLabel(id, label []byte, curve elliptic.Cu
 func (c *Context) GenerateECKeyPairWithAttributes(public, private AttributeSet, curve elliptic.Curve, typ *EcType) (crypto.PrivateKey, error) {
 	if c.closed.Get() {
 		return nil, errClosed
+	}
+	if typ == nil {
+		return nil, errors.New("ec key type is required")
+	}
+	if curve == nil {
+		return nil, errors.New("elliptic curve is required")
 	}
 
 	var k crypto.PrivateKey
@@ -252,6 +259,17 @@ func (key *pkcs11PrivateKeyEC) Derive(template AttributeSet, cipher *SymmetricCi
 	if key.context.closed.Get() {
 		return nil, errClosed
 	}
+	if cipher == nil {
+		return nil, errors.New("symmetric cipher is required")
+	}
+
+	if len(cipher.GenParams) == 0 {
+		return nil, errors.New("symmetric cipher has no key generation parameters")
+	}
+
+	if template == nil {
+		template = NewAttributeSet()
+	}
 
 	var mech *pkcs11.Mechanism
 	switch opts.(type) {
@@ -269,9 +287,9 @@ func (key *pkcs11PrivateKeyEC) Derive(template AttributeSet, cipher *SymmetricCi
 		if !ok || info.curve == nil {
 			return nil, errors.New("unsupported curve for ECDH derive")
 		}
-		bits = (info.curve.Params().BitSize + 7) / 8
+		bits = info.curve.Params().BitSize
 	case *ecdsa.PublicKey:
-		bits = (k.Curve.Params().BitSize + 7) / 8
+		bits = k.Curve.Params().BitSize
 	default:
 		return nil, errors.New("unsupported public key type for ECDH derive")
 	}
@@ -285,29 +303,40 @@ func (key *pkcs11PrivateKeyEC) Derive(template AttributeSet, cipher *SymmetricCi
 		pkcs11.NewAttribute(pkcs11.CKA_DECRYPT, cipher.Encrypt),
 		pkcs11.NewAttribute(pkcs11.CKA_SENSITIVE, true),
 		pkcs11.NewAttribute(pkcs11.CKA_EXTRACTABLE, false),
-		pkcs11.NewAttribute(pkcs11.CKA_VALUE_LEN, bits),
+		pkcs11.NewAttribute(pkcs11.CKA_VALUE_LEN, (bits+7)/8),
 	})
 
-	var secret *SecretKey
-	err := key.context.withSession(func(session *pkcs11Session) error {
-		keyHandle, err := session.ctx.DeriveKey(session.handle,
-			[]*pkcs11.Mechanism{mech},
-			key.handle,
-			template.ToSlice(),
-		)
-		if err != nil {
-			return err
+	var deriveErr error
+	for _, genMech := range cipher.GenParams {
+		if err := template.Set(pkcs11.CKA_KEY_TYPE, genMech.KeyType); err != nil {
+			return nil, err
 		}
 
-		secret = &SecretKey{
-			pkcs11Object: pkcs11Object{
-				handle:  keyHandle,
-				context: key.context,
-			},
-			Cipher: cipher,
-		}
-		return nil
-	})
+		var secret *SecretKey
+		deriveErr = key.context.withSession(func(session *pkcs11Session) error {
+			keyHandle, err := session.ctx.DeriveKey(session.handle,
+				[]*pkcs11.Mechanism{mech},
+				key.handle,
+				template.ToSlice(),
+			)
+			if err != nil {
+				return err
+			}
 
-	return secret, err
+			secret = &SecretKey{
+				pkcs11Object: pkcs11Object{
+					handle:  keyHandle,
+					context: key.context,
+				},
+				Cipher: cipher,
+			}
+			return nil
+		})
+
+		if deriveErr == nil {
+			return secret, nil
+		}
+	}
+
+	return nil, deriveErr
 }

--- a/ec.go
+++ b/ec.go
@@ -1,0 +1,313 @@
+package crypto11
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ecdh"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"encoding/asn1"
+	"fmt"
+	"io"
+
+	"github.com/miekg/pkcs11"
+	"github.com/pkg/errors"
+)
+
+// errUnsupportedEcdhCurve is returned when an edch curve
+// unsupported by crypto11 is specified.  Note that the error behavior
+// for an edch curve unsupported by the underlying PKCS#11
+// implementation will be different.
+var errUnsupportedEcdhCurve = errors.New("unsupported ecdh curve")
+
+// pkcs11PrivateKeyEC contains a reference to a loaded PKCS#11 EC private key object.
+type pkcs11PrivateKeyEC struct {
+	pkcs11PrivateKey
+}
+
+// Ensure pkcs11PrivateKeyEC implements Signer and Deriver.
+var (
+	_ Signer  = (*pkcs11PrivateKeyEC)(nil)
+	_ Deriver = (*pkcs11PrivateKeyEC)(nil)
+)
+
+// EcType is used to specify the intended use of an EC key pair when generating it.
+type EcType struct {
+	isDerive bool
+	isVerify bool
+	isSign   bool
+}
+
+var ECDH = &EcType{
+	isDerive: true,
+	isVerify: false,
+	isSign:   false,
+}
+
+var ECDSA = &EcType{
+	isDerive: false,
+	isVerify: true,
+	isSign:   true,
+}
+
+// Note: some of these are outside what crypto/elliptic currently
+// knows about. So I'm making a (reasonable) assumption about what
+// they will be called if they are either added or if someone
+// specifies them explicitly.
+//
+// For public key export, the curve has to be a known one, otherwise
+// you're stuffed. This is probably better fixed by adding well-known
+// curves to crypto/elliptic rather than having a private copy here.
+var wellKnownEcdhCurves = map[string]struct {
+	oid   []byte
+	curve ecdh.Curve
+}{
+	"P-256": {
+		mustMarshal(asn1.ObjectIdentifier{1, 2, 840, 10045, 3, 1, 7}),
+		ecdh.P256(),
+	},
+	"P-384": {
+		mustMarshal(asn1.ObjectIdentifier{1, 3, 132, 0, 34}),
+		ecdh.P384(),
+	},
+	"P-521": {
+		mustMarshal(asn1.ObjectIdentifier{1, 3, 132, 0, 35}),
+		ecdh.P521(),
+	},
+}
+
+func unmarshalEcdhParams(b []byte) (ecdh.Curve, error) {
+	// See if it's a well-known curve
+	for _, ci := range wellKnownEcdhCurves {
+		if bytes.Equal(b, ci.oid) {
+			if ci.curve != nil {
+				return ci.curve, nil
+			}
+			return nil, errUnsupportedEcdhCurve
+		}
+	}
+
+	return nil, errUnsupportedEcdhCurve
+}
+
+func unmarshalEcdhPoint(b []byte, c ecdh.Curve) (*ecdh.PublicKey, error) {
+	var pointBytes []byte
+	extra, err := asn1.Unmarshal(b, &pointBytes)
+	if err != nil {
+		return nil, errors.WithMessage(err, "elliptic curve point is invalid ASN.1")
+	}
+
+	if len(extra) > 0 {
+		// We weren't expecting extra data
+		return nil, errors.New("unexpected data found when parsing elliptic curve point")
+	}
+
+	return c.NewPublicKey(pointBytes)
+}
+
+// Export the public key corresponding to a private EC key.
+func exportECPublicKey(session *pkcs11Session, pubHandle pkcs11.ObjectHandle) (crypto.PublicKey, error) {
+	var err error
+	var attributes []*pkcs11.Attribute
+	template := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_EC_PARAMS, nil),
+		pkcs11.NewAttribute(pkcs11.CKA_EC_POINT, nil),
+		pkcs11.NewAttribute(pkcs11.CKA_DERIVE, nil),
+	}
+	if attributes, err = session.ctx.GetAttributeValue(session.handle, pubHandle, template); err != nil {
+		return nil, err
+	}
+
+	if len(attributes) != len(template) {
+		return nil, errors.Errorf("expected %d attributes but got %d", len(template), len(attributes))
+	}
+
+	params, point, isDerive := attributes[0], attributes[1], attributes[2]
+
+	if bytesToBool(isDerive.Value) {
+		curve, err := unmarshalEcdhParams(params.Value)
+		if err != nil {
+			return nil, err
+		}
+
+		return unmarshalEcdhPoint(point.Value, curve)
+	} else {
+		var pub ecdsa.PublicKey
+		if pub.Curve, err = unmarshalEcParams(params.Value); err != nil {
+			return nil, err
+		}
+		if pub.X, pub.Y, err = unmarshalEcPoint(point.Value, pub.Curve); err != nil {
+			return nil, err
+		}
+		return &pub, nil
+	}
+
+}
+
+// GenerateECKeyPair creates a EC key pair on the token using curve c. The id parameter is used to
+// set CKA_ID and must be non-nil. Only a limited set of named elliptic curves are supported. The
+// underlying PKCS#11 implementation may impose further restrictions.
+func (c *Context) GenerateECKeyPair(id []byte, curve elliptic.Curve, typ *EcType) (crypto.PrivateKey, error) {
+	if c.closed.Get() {
+		return nil, errClosed
+	}
+
+	public, err := NewAttributeSetWithID(id)
+	if err != nil {
+		return nil, err
+	}
+	// Copy the AttributeSet to allow modifications.
+	private := public.Copy()
+
+	return c.GenerateECKeyPairWithAttributes(public, private, curve, typ)
+}
+
+// GenerateECKeyPairWithLabel creates a EC key pair on the token using curve c. The id and label parameters are used to
+// set CKA_ID and CKA_LABEL respectively and must be non-nil. Only a limited set of named elliptic curves are supported. The
+// underlying PKCS#11 implementation may impose further restrictions.
+func (c *Context) GenerateECKeyPairWithLabel(id, label []byte, curve elliptic.Curve, typ *EcType) (crypto.PrivateKey, error) {
+	if c.closed.Get() {
+		return nil, errClosed
+	}
+
+	public, err := NewAttributeSetWithIDAndLabel(id, label)
+	if err != nil {
+		return nil, err
+	}
+	// Copy the AttributeSet to allow modifications.
+	private := public.Copy()
+
+	return c.GenerateECKeyPairWithAttributes(public, private, curve, typ)
+}
+
+// GenerateECKeyPairWithAttributes generates an EC key pair on the token. After this function returns, public and
+// private will contain the attributes applied to the key pair. If required attributes are missing, they will be set to
+// a default value.
+func (c *Context) GenerateECKeyPairWithAttributes(public, private AttributeSet, curve elliptic.Curve, typ *EcType) (crypto.PrivateKey, error) {
+	if c.closed.Get() {
+		return nil, errClosed
+	}
+
+	var k crypto.PrivateKey
+	err := c.withSession(func(session *pkcs11Session) error {
+
+		parameters, err := marshalEcParams(curve)
+		if err != nil {
+			return err
+		}
+		public.AddIfNotPresent([]*pkcs11.Attribute{
+			pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_PUBLIC_KEY),
+			pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, pkcs11.CKK_EC),
+			pkcs11.NewAttribute(pkcs11.CKA_TOKEN, true),
+			pkcs11.NewAttribute(pkcs11.CKA_VERIFY, typ.isVerify),
+			pkcs11.NewAttribute(pkcs11.CKA_EC_PARAMS, parameters),
+		})
+		private.AddIfNotPresent([]*pkcs11.Attribute{
+			pkcs11.NewAttribute(pkcs11.CKA_TOKEN, true),
+			pkcs11.NewAttribute(pkcs11.CKA_SIGN, typ.isSign),
+			pkcs11.NewAttribute(pkcs11.CKA_DERIVE, typ.isDerive),
+			pkcs11.NewAttribute(pkcs11.CKA_SENSITIVE, true),
+			pkcs11.NewAttribute(pkcs11.CKA_EXTRACTABLE, false),
+		})
+
+		mech := []*pkcs11.Mechanism{pkcs11.NewMechanism(pkcs11.CKM_EC_KEY_PAIR_GEN, nil)}
+		pubHandle, privHandle, err := session.ctx.GenerateKeyPair(session.handle,
+			mech,
+			public.ToSlice(),
+			private.ToSlice())
+		if err != nil {
+			return err
+		}
+
+		pub, err := exportECPublicKey(session, pubHandle)
+		if err != nil {
+			return err
+		}
+		k = &pkcs11PrivateKeyEC{
+			pkcs11PrivateKey: pkcs11PrivateKey{
+				pkcs11Object: pkcs11Object{
+					handle:  privHandle,
+					context: c,
+				},
+				pubKeyHandle: pubHandle,
+				pubKey:       pub,
+			}}
+		return nil
+	})
+	return k, err
+}
+
+// Sign signs a message using an ECDSA key.
+//
+// This completes the implemention of crypto.Signer for pkcs11PrivateKeyEC.
+//
+// PKCS#11 expects to pick its own random data where necessary for signatures, so the rand argument is ignored.
+//
+// The return value is a DER-encoded byteblock.
+func (key *pkcs11PrivateKeyEC) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	return key.context.dsaGeneric(key.handle, pkcs11.CKM_ECDSA, digest)
+}
+
+func (key *pkcs11PrivateKeyEC) Derive(template AttributeSet, cipher *SymmetricCipher, opts any) (*SecretKey, error) {
+	if key.context.closed.Get() {
+		return nil, errClosed
+	}
+
+	var mech *pkcs11.Mechanism
+	switch opts.(type) {
+	case *pkcs11.ECDH1DeriveParams:
+		mech = pkcs11.NewMechanism(pkcs11.CKM_ECDH1_DERIVE, opts)
+	default:
+		return nil, errors.New("unsupported ECDH derive parameters")
+	}
+
+	// get the public key attributes to determine the size of the derived secret
+	var bits int
+	switch k := key.pubKey.(type) {
+	case *ecdh.PublicKey:
+		info, ok := wellKnownCurves[fmt.Sprintf("%s", k.Curve())]
+		if !ok || info.curve == nil {
+			return nil, errors.New("unsupported curve for ECDH derive")
+		}
+		bits = (info.curve.Params().BitSize + 7) / 8
+	case *ecdsa.PublicKey:
+		bits = (k.Curve.Params().BitSize + 7) / 8
+	default:
+		return nil, errors.New("unsupported public key type for ECDH derive")
+	}
+
+	template.AddIfNotPresent([]*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_SECRET_KEY),
+		pkcs11.NewAttribute(pkcs11.CKA_TOKEN, false),
+		pkcs11.NewAttribute(pkcs11.CKA_SIGN, cipher.MAC),
+		pkcs11.NewAttribute(pkcs11.CKA_VERIFY, cipher.MAC),
+		pkcs11.NewAttribute(pkcs11.CKA_ENCRYPT, cipher.Encrypt),
+		pkcs11.NewAttribute(pkcs11.CKA_DECRYPT, cipher.Encrypt),
+		pkcs11.NewAttribute(pkcs11.CKA_SENSITIVE, true),
+		pkcs11.NewAttribute(pkcs11.CKA_EXTRACTABLE, false),
+		pkcs11.NewAttribute(pkcs11.CKA_VALUE_LEN, bits),
+	})
+
+	var secret *SecretKey
+	err := key.context.withSession(func(session *pkcs11Session) error {
+		keyHandle, err := session.ctx.DeriveKey(session.handle,
+			[]*pkcs11.Mechanism{mech},
+			key.handle,
+			template.ToSlice(),
+		)
+		if err != nil {
+			return err
+		}
+
+		secret = &SecretKey{
+			pkcs11Object: pkcs11Object{
+				handle:  keyHandle,
+				context: key.context,
+			},
+			Cipher: cipher,
+		}
+		return nil
+	})
+
+	return secret, err
+}

--- a/ec.go
+++ b/ec.go
@@ -145,9 +145,33 @@ func exportECPublicKey(session *pkcs11Session, pubHandle pkcs11.ObjectHandle) (c
 	}
 }
 
-// GenerateECKeyPair creates a EC key pair on the token using curve c. The id parameter is used to
-// set CKA_ID and must be non-nil. Only a limited set of named elliptic curves are supported. The
-// underlying PKCS#11 implementation may impose further restrictions.
+// GenerateECKeyPair creates an EC key pair on the token using curve.
+//
+// Parameters:
+//   - id sets CKA_ID and must be non-nil.
+//   - curve is the named elliptic curve to generate on token (for example elliptic.P256()).
+//   - typ declares intended key usage (for example [ECDH] for derive-only, [ECDSA] for sign/verify).
+//
+// Return value:
+//   - The returned crypto.PrivateKey must be type-asserted by callers to the interface/struct they need.
+//     For example, for ECDH key agreement you typically assert to [Deriver], and then assert the public
+//     key to [*ecdh.PublicKey]. For ECDSA signing, you typically assert to [Signer] and then assert
+//     the public key to [*ecdsa.PublicKey].
+//
+// Example (ECDH):
+//
+//	key, err := ctx.GenerateECKeyPair([]byte("test"), elliptic.P256(), ECDH)
+//	if err != nil {
+//		// handle error
+//	}
+//	deriver, ok := key.(Deriver)
+//	if !ok {
+//		// handle unexpected key type
+//	}
+//	pub, ok := key.Public().(*ecdh.PublicKey)
+//	if !ok {
+//		// handle unexpected public key type
+//	}
 func (c *Context) GenerateECKeyPair(id []byte, curve elliptic.Curve, typ *EcType) (crypto.PrivateKey, error) {
 	if c.closed.Get() {
 		return nil, errClosed
@@ -163,9 +187,19 @@ func (c *Context) GenerateECKeyPair(id []byte, curve elliptic.Curve, typ *EcType
 	return c.GenerateECKeyPairWithAttributes(public, private, curve, typ)
 }
 
-// GenerateECKeyPairWithLabel creates a EC key pair on the token using curve c. The id and label parameters are used to
-// set CKA_ID and CKA_LABEL respectively and must be non-nil. Only a limited set of named elliptic curves are supported. The
-// underlying PKCS#11 implementation may impose further restrictions.
+// GenerateECKeyPairWithLabel creates an EC key pair on the token using curve.
+//
+// Parameters:
+//   - id sets CKA_ID and must be non-nil.
+//   - label sets CKA_LABEL and must be non-nil.
+//   - curve is the named elliptic curve to generate on token.
+//   - typ declares intended key usage ([ECDH] or [ECDSA]).
+//
+// Return value:
+//   - The returned crypto.PrivateKey must be type-asserted by callers to the interface/struct they need.
+//     For example, for ECDH key agreement you typically assert to [Deriver], and then assert the public
+//     key to [*ecdh.PublicKey]. For ECDSA signing, you typically assert to [Signer] and then assert
+//     the public key to [*ecdsa.PublicKey].
 func (c *Context) GenerateECKeyPairWithLabel(id, label []byte, curve elliptic.Curve, typ *EcType) (crypto.PrivateKey, error) {
 	if c.closed.Get() {
 		return nil, errClosed
@@ -181,9 +215,40 @@ func (c *Context) GenerateECKeyPairWithLabel(id, label []byte, curve elliptic.Cu
 	return c.GenerateECKeyPairWithAttributes(public, private, curve, typ)
 }
 
-// GenerateECKeyPairWithAttributes generates an EC key pair on the token. After this function returns, public and
-// private will contain the attributes applied to the key pair. If required attributes are missing, they will be set to
-// a default value.
+// GenerateECKeyPairWithAttributes generates an EC key pair on the token with caller-provided
+// public/private attribute sets.
+//
+// Parameters:
+//   - public is the attribute set applied to the public key object.
+//   - private is the attribute set applied to the private key object.
+//   - curve is the named elliptic curve used for key generation.
+//   - typ declares intended key usage ([ECDH] or [ECDSA]) and drives default usage attributes.
+//
+// Behavior:
+//   - After this function returns, public and private contain the effective attributes applied
+//     to the generated key objects.
+//   - If required attributes are missing, defaults are applied.
+//
+// Return value:
+//   - The returned crypto.PrivateKey must be type-asserted by callers to the interface/struct they need.
+//     For example, for ECDH key agreement you typically assert to [Deriver], and then assert the public
+//     key to [*ecdh.PublicKey]. For ECDSA signing, you typically assert to [Signer] and then assert
+//     the public key to [*ecdsa.PublicKey].
+//
+// Example:
+//
+//	key, err := ctx.GenerateECKeyPairWithAttributes(publicAttrs, privateAttrs, elliptic.P256(), ECDH)
+//	if err != nil {
+//	// handle error
+//	}
+//	deriver, ok := key.(Deriver)
+//	if !ok {
+//	// handle unexpected key type
+//	}
+//	pub, ok := key.Public().(*ecdh.PublicKey)
+//	if !ok {
+//	// handle unexpected public key type
+//	}
 func (c *Context) GenerateECKeyPairWithAttributes(public, private AttributeSet, curve elliptic.Curve, typ *EcType) (crypto.PrivateKey, error) {
 	if c.closed.Get() {
 		return nil, errClosed
@@ -255,6 +320,11 @@ func (key *pkcs11PrivateKeyEC) Sign(rand io.Reader, digest []byte, opts crypto.S
 	return key.context.dsaGeneric(key.handle, pkcs11.CKM_ECDSA, digest)
 }
 
+// Derive derives a secret key from the given ECDH private key and a public key.
+// The template is used to specify attributes for the derived key,
+// and the cipher is used to specify the intended use of the derived key.
+// The opts argument is used to specify parameters for the derive operation,
+// such as the KDF to use and any KDF-specific parameters.
 func (key *pkcs11PrivateKeyEC) Derive(template AttributeSet, cipher *SymmetricCipher, opts any) (*SecretKey, error) {
 	if key.context.closed.Get() {
 		return nil, errClosed
@@ -271,28 +341,24 @@ func (key *pkcs11PrivateKeyEC) Derive(template AttributeSet, cipher *SymmetricCi
 		template = NewAttributeSet()
 	}
 
-	var mech *pkcs11.Mechanism
-	switch opts.(type) {
+	var (
+		mech    *pkcs11.Mechanism
+		keySize int
+	)
+
+	switch o := opts.(type) {
 	case *pkcs11.ECDH1DeriveParams:
-		mech = pkcs11.NewMechanism(pkcs11.CKM_ECDH1_DERIVE, opts)
+		mech = pkcs11.NewMechanism(pkcs11.CKM_ECDH1_DERIVE, o)
+		l, err := getECDH1KeySize(o.KDF, key.Public())
+		if err != nil {
+			return nil, err
+		}
+		keySize = l
 	default:
 		return nil, errors.New("unsupported ECDH derive parameters")
 	}
 
 	// get the public key attributes to determine the size of the derived secret
-	var bits int
-	switch k := key.pubKey.(type) {
-	case *ecdh.PublicKey:
-		info, ok := wellKnownCurves[fmt.Sprintf("%s", k.Curve())]
-		if !ok || info.curve == nil {
-			return nil, errors.New("unsupported curve for ECDH derive")
-		}
-		bits = info.curve.Params().BitSize
-	case *ecdsa.PublicKey:
-		bits = k.Curve.Params().BitSize
-	default:
-		return nil, errors.New("unsupported public key type for ECDH derive")
-	}
 
 	template.AddIfNotPresent([]*pkcs11.Attribute{
 		pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_SECRET_KEY),
@@ -303,7 +369,7 @@ func (key *pkcs11PrivateKeyEC) Derive(template AttributeSet, cipher *SymmetricCi
 		pkcs11.NewAttribute(pkcs11.CKA_DECRYPT, cipher.Encrypt),
 		pkcs11.NewAttribute(pkcs11.CKA_SENSITIVE, true),
 		pkcs11.NewAttribute(pkcs11.CKA_EXTRACTABLE, false),
-		pkcs11.NewAttribute(pkcs11.CKA_VALUE_LEN, (bits+7)/8),
+		pkcs11.NewAttribute(pkcs11.CKA_VALUE_LEN, keySize),
 	})
 
 	var deriveErr error
@@ -339,4 +405,39 @@ func (key *pkcs11PrivateKeyEC) Derive(template AttributeSet, cipher *SymmetricCi
 	}
 
 	return nil, deriveErr
+}
+
+var wellKnownEcdh1KDFKeySize = map[uint]int{}
+
+// RegisterECDH1CustomKDF allows users to register a custom KDF and key size for ECDH derive operations. '
+// This is necessary for compatibility with some PKCS#11 implementations,
+// such as AWS CloudHSM, that require the use of a custom KDF for ECDH derive operations.
+// The key size is the length in bytes of the derived secret.
+func RegisterECDH1CustomKDF(keyType uint, keySize int) error {
+	if _, ok := wellKnownEcdh1KDFKeySize[keyType]; ok {
+		return errors.Errorf("a key size is already registered for KDF type %d", keyType)
+	}
+
+	wellKnownEcdh1KDFKeySize[keyType] = keySize
+	return nil
+}
+
+func getECDH1KeySize(KDF uint, pubKey crypto.PublicKey) (int, error) {
+	if KDF == pkcs11.CKD_NULL {
+		if k, ok := pubKey.(*ecdh.PublicKey); ok {
+			info, ok := wellKnownCurves[fmt.Sprintf("%s", k.Curve())]
+			if !ok || info.curve == nil {
+				return 0, errors.New("unsupported curve for ECDH derive")
+			}
+			return (info.curve.Params().BitSize + 7) / 8, nil
+		} else {
+			return 0, errors.New("unsupported public key type for ECDH derive")
+		}
+	} else {
+		l, ok := wellKnownEcdh1KDFKeySize[KDF]
+		if !ok {
+			return 0, errors.Errorf("unsupported KDF for ECDH derive: %d", KDF)
+		}
+		return l, nil
+	}
 }

--- a/ec_test.go
+++ b/ec_test.go
@@ -180,3 +180,14 @@ func TestECDHDeriveRequiredArgs(t *testing.T) {
 	_, err = key.Derive(NewAttributeSet(), CipherGeneric, nil)
 	require.Error(t, err)
 }
+
+func TestRegisterECDH1CustomKDF(t *testing.T) {
+	const CKD_CUSTOM_SHA256_KDF = pkcs11.CKO_VENDOR_DEFINED | pkcs11.CKD_SHA256_KDF
+
+	err := RegisterECDH1CustomKDF(CKD_CUSTOM_SHA256_KDF, 32)
+	require.NoError(t, err)
+
+	// registering the same KDF again should fail
+	err = RegisterECDH1CustomKDF(CKD_CUSTOM_SHA256_KDF, 32)
+	require.Error(t, err)
+}

--- a/ec_test.go
+++ b/ec_test.go
@@ -1,0 +1,182 @@
+package crypto11
+
+import (
+	"crypto"
+	"crypto/ecdh"
+	"crypto/elliptic"
+	"crypto/rand"
+	_ "crypto/sha1"
+	_ "crypto/sha256"
+	_ "crypto/sha512"
+	"fmt"
+	"testing"
+
+	"github.com/miekg/pkcs11"
+	"github.com/stretchr/testify/require"
+)
+
+var ecdhCurves = []ecdh.Curve{
+	ecdh.P256(),
+	ecdh.P384(),
+	ecdh.P521(),
+	// plus something with explicit parameters
+}
+
+func TestEcDerive(t *testing.T) {
+	ctx, err := ConfigureFromFile("config")
+	require.NoError(t, err)
+
+	defer func() {
+		err = ctx.Close()
+		require.NoError(t, err)
+	}()
+
+	id := randomBytes()
+	label := randomBytes()
+
+	for _, curve := range ecdhCurves {
+		c, ok := wellKnownCurves[fmt.Sprintf("%s", curve)]
+		if !ok {
+			t.Errorf("unsupported curve: %s", curve)
+			return
+		}
+
+		key, err := ctx.GenerateECKeyPairWithLabel(id, label, c.curve, ECDH)
+		require.NoError(t, err)
+		hsmKey, ok := key.(Deriver)
+		if !ok {
+			require.Fail(t, "key does not implement crypto.Deriver")
+			return
+		}
+		defer func(k Deriver) { _ = k.Delete() }(hsmKey)
+
+		nativeKey, err := curve.GenerateKey(rand.Reader)
+		require.NoError(t, err)
+
+		testSymmetricCiphes := []*SymmetricCipher{CipherGeneric}
+		// only P-256 can be used with AES when KDF is CKD_NULL, because the shared secret is 32 bytes long, which is the key size for AES-256
+		if c.curve.Params().Name == "P-256" {
+			testSymmetricCiphes = append(testSymmetricCiphes, CipherAES)
+		}
+
+		for _, cipher := range testSymmetricCiphes {
+			template := NewAttributeSet()
+			template.AddIfNotPresent([]*pkcs11.Attribute{
+				pkcs11.NewAttribute(pkcs11.CKA_SENSITIVE, false),
+				pkcs11.NewAttribute(pkcs11.CKA_EXTRACTABLE, true),
+			})
+
+			secret, err := hsmKey.Derive(template, cipher, &pkcs11.ECDH1DeriveParams{
+				KDF:           pkcs11.CKD_NULL,
+				PublicKeyData: nativeKey.Public().(*ecdh.PublicKey).Bytes(),
+			})
+			require.NoError(t, err)
+			shared1, err := getSharedSecretValue(secret)
+			require.NoError(t, err)
+
+			shared2, err := nativeKey.ECDH(hsmKey.Public().(*ecdh.PublicKey))
+			require.NoError(t, err)
+
+			require.Equal(t, shared1, shared2)
+		}
+	}
+}
+
+func getSharedSecretValue(secret *SecretKey) ([]byte, error) {
+	var buf []byte
+	err := secret.context.withSession(func(session *pkcs11Session) error {
+		template := []*pkcs11.Attribute{
+			pkcs11.NewAttribute(pkcs11.CKA_VALUE, nil),
+		}
+		attr, err := session.ctx.GetAttributeValue(session.handle, secret.handle, template)
+		if err != nil {
+			return err
+		}
+		buf = attr[0].Value
+		return nil
+	})
+	return buf, err
+}
+
+func TestEcSigning(t *testing.T) {
+	ctx, err := ConfigureFromFile("config")
+	require.NoError(t, err)
+
+	defer func() {
+		err = ctx.Close()
+		require.NoError(t, err)
+	}()
+
+	for _, curve := range curves {
+		id := randomBytes()
+		label := randomBytes()
+
+		key, err := ctx.GenerateECKeyPairWithLabel(id, label, curve, ECDSA)
+		require.NoError(t, err)
+		require.NotNil(t, key)
+		signer, ok := key.(Signer)
+		if !ok {
+			require.Fail(t, "key does not implement crypto.Signer")
+			return
+		}
+		defer func(k Signer) { _ = k.Delete() }(signer)
+
+		testEcdsaSigning(t, signer, crypto.SHA1, curve.Params().Name, "SHA-1")
+		testEcdsaSigning(t, signer, crypto.SHA224, curve.Params().Name, "SHA-224")
+		testEcdsaSigning(t, signer, crypto.SHA256, curve.Params().Name, "SHA-256")
+		testEcdsaSigning(t, signer, crypto.SHA384, curve.Params().Name, "SHA-384")
+		testEcdsaSigning(t, signer, crypto.SHA512, curve.Params().Name, "SHA-512")
+
+		key2, err := ctx.FindKeyPair(id, nil)
+		require.NoError(t, err)
+		testEcdsaSigning(t, key2.(*pkcs11PrivateKeyEC), crypto.SHA256, curve.Params().Name, "SHA-256")
+
+		key3, err := ctx.FindKeyPair(nil, label)
+		require.NoError(t, err)
+		testEcdsaSigning(t, key3.(crypto.Signer), crypto.SHA384, curve.Params().Name, "SHA-384")
+	}
+}
+
+func TestECRequiredArgs(t *testing.T) {
+	ctx, err := ConfigureFromFile("config")
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, ctx.Close())
+	}()
+
+	_, err = ctx.GenerateECKeyPair(nil, elliptic.P224(), ECDSA)
+	require.Error(t, err)
+
+	id := randomBytes()
+
+	_, err = ctx.GenerateECKeyPair(id, elliptic.P224(), nil)
+	require.Error(t, err)
+
+	val := randomBytes()
+
+	_, err = ctx.GenerateECKeyPairWithLabel(nil, val, elliptic.P224(), ECDSA)
+	require.Error(t, err)
+
+	_, err = ctx.GenerateECKeyPairWithLabel(val, nil, elliptic.P224(), ECDSA)
+	require.Error(t, err)
+}
+
+func TestECDHDeriveRequiredArgs(t *testing.T) {
+	key := &pkcs11PrivateKeyEC{
+		pkcs11PrivateKey: pkcs11PrivateKey{
+			pkcs11Object: pkcs11Object{
+				context: &Context{},
+			},
+		},
+	}
+
+	_, err := key.Derive(NewAttributeSet(), &SymmetricCipher{}, nil)
+	require.Error(t, err)
+
+	_, err = key.Derive(NewAttributeSet(), nil, nil)
+	require.Error(t, err)
+
+	_, err = key.Derive(NewAttributeSet(), CipherGeneric, nil)
+	require.Error(t, err)
+}

--- a/ecdsa.go
+++ b/ecdsa.go
@@ -205,6 +205,8 @@ func exportECDSAPublicKey(session *pkcs11Session, pubHandle pkcs11.ObjectHandle)
 // GenerateECDSAKeyPair creates a ECDSA key pair on the token using curve c. The id parameter is used to
 // set CKA_ID and must be non-nil. Only a limited set of named elliptic curves are supported. The
 // underlying PKCS#11 implementation may impose further restrictions.
+//
+// Deprecated: use [GenerateECKeyPair] instead to have more functionality.
 func (c *Context) GenerateECDSAKeyPair(id []byte, curve elliptic.Curve) (Signer, error) {
 	if c.closed.Get() {
 		return nil, errClosed
@@ -223,6 +225,8 @@ func (c *Context) GenerateECDSAKeyPair(id []byte, curve elliptic.Curve) (Signer,
 // GenerateECDSAKeyPairWithLabel creates a ECDSA key pair on the token using curve c. The id and label parameters are used to
 // set CKA_ID and CKA_LABEL respectively and must be non-nil. Only a limited set of named elliptic curves are supported. The
 // underlying PKCS#11 implementation may impose further restrictions.
+//
+// Deprecated: use [GenerateECKeyPairWithLabel] instead to have more functionality.
 func (c *Context) GenerateECDSAKeyPairWithLabel(id, label []byte, curve elliptic.Curve) (Signer, error) {
 	if c.closed.Get() {
 		return nil, errClosed
@@ -241,6 +245,8 @@ func (c *Context) GenerateECDSAKeyPairWithLabel(id, label []byte, curve elliptic
 // GenerateECDSAKeyPairWithAttributes generates an ECDSA key pair on the token. After this function returns, public and
 // private will contain the attributes applied to the key pair. If required attributes are missing, they will be set to
 // a default value.
+//
+// Deprecated: use [GenerateECKeyPairWithAttributes] instead to have more functionality.
 func (c *Context) GenerateECDSAKeyPairWithAttributes(public, private AttributeSet, curve elliptic.Curve) (Signer, error) {
 	if c.closed.Get() {
 		return nil, errClosed

--- a/ecdsa_test.go
+++ b/ecdsa_test.go
@@ -88,7 +88,7 @@ func TestHardECDSA(t *testing.T) {
 
 		key2, err := ctx.FindKeyPair(id, nil)
 		require.NoError(t, err)
-		testEcdsaSigning(t, key2.(*pkcs11PrivateKeyECDSA), crypto.SHA256, curve.Params().Name, "SHA-256")
+		testEcdsaSigning(t, key2, crypto.SHA256, curve.Params().Name, "SHA-256")
 
 		key3, err := ctx.FindKeyPair(nil, label)
 		require.NoError(t, err)

--- a/keys.go
+++ b/keys.go
@@ -219,10 +219,10 @@ func (c *Context) makeKeyPair(session *pkcs11Session, privHandle *pkcs11.ObjectH
 		result.pkcs11PrivateKey.pubKey = pub
 		return result, certificate, nil
 
-	case pkcs11.CKK_ECDSA:
-		result := &pkcs11PrivateKeyECDSA{pkcs11PrivateKey: *resultPkcs11PrivateKey}
+	case pkcs11.CKK_EC:
+		result := &pkcs11PrivateKeyEC{pkcs11PrivateKey: *resultPkcs11PrivateKey}
 		if pubHandle != nil {
-			if pub, err = exportECDSAPublicKey(session, *pubHandle); err != nil {
+			if pub, err = exportECPublicKey(session, *pubHandle); err != nil {
 				return nil, nil, err
 			}
 			result.pkcs11PrivateKey.pubKeyHandle = *pubHandle


### PR DESCRIPTION
This PR introduces unified EC key generation APIs supporting both ECDSA signing and ECDH key agreement.

It improves the robustness of ECDH key derivation in PKCS#11 providers by adding stricter input validation and supporting custom ECDH1 KDF key-size registration.

EC public key export logic now uses CKA_VERIFY to distinguish between ECDSA and ECDH keys, improving compatibility with providers such as **AWS CloudHSM** .

Legacy ECDSA-only key generation APIs are retained for backward compatibility and marked as deprecated in favor of the new unified EC APIs.

## Note: 
This feature was originally introduced in PR #70. In that implementation, derived keys were returned directly as raw byte[], which could conflict with **PCI DSS** requirements. This PR refactors the approach to handle derived secrets securely, avoiding direct exposure of sensitive material.