### PR TITLE
Add ImportECDSAKeyPair to load existing EC keys onto a token

### DIFF
--- a/import.go
+++ b/import.go
@@ -1,0 +1,129 @@
+package crypto11
+
+import (
+	"crypto/ecdsa"
+	"encoding/asn1"
+
+	"github.com/miekg/pkcs11"
+	"github.com/pkg/errors"
+)
+
+// ImportECDSAKeyPair imports an existing ECDSA key pair onto the token. The id parameter is used to
+// set CKA_ID on both objects and must be non-nil. Only the named curves supported by crypto11 are
+// accepted. The underlying PKCS#11 implementation may impose further restrictions (e.g. on
+// importing private key material at all).
+func (c *Context) ImportECDSAKeyPair(id []byte, key *ecdsa.PrivateKey) (Signer, error) {
+	if c.closed.Get() {
+		return nil, errClosed
+	}
+
+	public, err := NewAttributeSetWithID(id)
+	if err != nil {
+		return nil, err
+	}
+	private := public.Copy()
+
+	return c.ImportECDSAKeyPairWithAttributes(public, private, key)
+}
+
+// ImportECDSAKeyPairWithLabel imports an existing ECDSA key pair onto the token. The id and label
+// parameters set CKA_ID and CKA_LABEL respectively and must be non-nil.
+func (c *Context) ImportECDSAKeyPairWithLabel(id, label []byte, key *ecdsa.PrivateKey) (Signer, error) {
+	if c.closed.Get() {
+		return nil, errClosed
+	}
+
+	public, err := NewAttributeSetWithIDAndLabel(id, label)
+	if err != nil {
+		return nil, err
+	}
+	private := public.Copy()
+
+	return c.ImportECDSAKeyPairWithAttributes(public, private, key)
+}
+
+// ImportECDSAKeyPairWithAttributes imports an existing ECDSA key pair onto the token. After this
+// function returns, public and private will contain the attributes applied to the imported objects.
+// The key material (CKA_EC_PARAMS, CKA_EC_POINT, CKA_VALUE) and the object classes are always set
+// from key; any other missing attributes are given default values, so callers may override
+// defaults such as CKA_SENSITIVE/CKA_EXTRACTABLE by presetting them on private.
+//
+// The two objects are created sequentially rather than atomically. If the private key is created
+// but the public key fails, the orphaned private key is destroyed before the error is returned.
+func (c *Context) ImportECDSAKeyPairWithAttributes(public, private AttributeSet, key *ecdsa.PrivateKey) (Signer, error) {
+	if c.closed.Get() {
+		return nil, errClosed
+	}
+	if key == nil {
+		return nil, errors.New("key cannot be nil")
+	}
+
+	parameters, err := marshalEcParams(key.Curve)
+	if err != nil {
+		return nil, err
+	}
+
+	// Use crypto/ecdh for the byte encodings, avoiding the deprecated elliptic/big.Int APIs.
+	// ECDH supports P-256/384/521 but not P-224, so a curve crypto11 can generate may not be
+	// importable; the error is explicit rather than a silent gap.
+	ecdhKey, err := key.ECDH()
+	if err != nil {
+		return nil, errors.WithMessage(err, "curve not supported for import")
+	}
+
+	// CKA_EC_POINT is the uncompressed point wrapped in a DER OCTET STRING, per PKCS#11.
+	// PublicKey.Bytes returns exactly that uncompressed encoding (0x04 || X || Y).
+	ecPoint, err := asn1.Marshal(ecdhKey.PublicKey().Bytes())
+	if err != nil {
+		return nil, err
+	}
+
+	// PrivateKey.Bytes is the fixed-length big-endian scalar, matching CKA_VALUE.
+	value := ecdhKey.Bytes()
+
+	public.AddIfNotPresent([]*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_TOKEN, true),
+		pkcs11.NewAttribute(pkcs11.CKA_VERIFY, true),
+	})
+	// CKA_CLASS, CKA_KEY_TYPE and the key material define the object; set them unconditionally.
+	_ = public.Set(CkaClass, pkcs11.CKO_PUBLIC_KEY)
+	_ = public.Set(CkaKeyType, pkcs11.CKK_ECDSA)
+	_ = public.Set(CkaEcParams, parameters)
+	_ = public.Set(CkaEcPoint, ecPoint)
+
+	private.AddIfNotPresent([]*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_TOKEN, true),
+		pkcs11.NewAttribute(pkcs11.CKA_SIGN, true),
+	})
+	_ = private.Set(CkaClass, pkcs11.CKO_PRIVATE_KEY)
+	_ = private.Set(CkaKeyType, pkcs11.CKK_ECDSA)
+	_ = private.Set(CkaEcParams, parameters)
+	_ = private.Set(CkaValue, value)
+
+	var k Signer
+	err = c.withSession(func(session *pkcs11Session) error {
+		pubHandle, err := session.ctx.CreateObject(session.handle, public.ToSlice())
+		if err != nil {
+			return err
+		}
+
+		privHandle, err := session.ctx.CreateObject(session.handle, private.ToSlice())
+		if err != nil {
+			// Roll back the orphaned public key so a retry sees a clean token.
+			_ = session.ctx.DestroyObject(session.handle, pubHandle)
+			return err
+		}
+
+		k = &pkcs11PrivateKeyECDSA{
+			pkcs11PrivateKey: pkcs11PrivateKey{
+				pkcs11Object: pkcs11Object{
+					handle:  privHandle,
+					context: c,
+				},
+				pubKeyHandle: pubHandle,
+				pubKey:       &key.PublicKey,
+			}}
+		return nil
+	})
+	return k, err
+}

--- a/import_test.go
+++ b/import_test.go
@@ -1,0 +1,75 @@
+package crypto11
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	_ "crypto/sha256"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestHardImportECDSA imports a software-generated key onto the token and proves the imported
+// key is usable: it signs verifiably under its own public key, and FindKeyPair retrieves the same
+// key by id and by label. crypto/ecdh covers P-256/384/521; P-224 is exercised separately below.
+func TestHardImportECDSA(t *testing.T) {
+	ctx, err := ConfigureFromFile("config")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, ctx.Close()) }()
+
+	importCurves := []elliptic.Curve{elliptic.P256(), elliptic.P384(), elliptic.P521()}
+	for _, curve := range importCurves {
+		key, err := ecdsa.GenerateKey(curve, rand.Reader)
+		require.NoError(t, err)
+
+		id := randomBytes()
+		label := randomBytes()
+
+		imported, err := ctx.ImportECDSAKeyPairWithLabel(id, label, key)
+		require.NoError(t, err)
+		require.NotNil(t, imported)
+		defer func(k Signer) { _ = k.Delete() }(imported)
+
+		// The handle's public key must be the one we imported.
+		require.True(t, key.PublicKey.Equal(imported.Public()),
+			"imported public key differs from source for %s", curve.Params().Name)
+
+		// Signs verifiably, and is independently retrievable.
+		testEcdsaSigning(t, imported, crypto.SHA256, curve.Params().Name, "SHA-256")
+
+		byID, err := ctx.FindKeyPair(id, nil)
+		require.NoError(t, err)
+		require.NotNil(t, byID)
+		testEcdsaSigning(t, byID.(crypto.Signer), crypto.SHA256, curve.Params().Name, "SHA-256")
+
+		byLabel, err := ctx.FindKeyPair(nil, label)
+		require.NoError(t, err)
+		require.NotNil(t, byLabel)
+	}
+}
+
+// TestHardImportECDSAUnsupportedCurve documents the one asymmetry with keygen: crypto/ecdh has no
+// P-224, so a P-224 key cannot be imported and the failure is explicit rather than silent.
+func TestHardImportECDSAUnsupportedCurve(t *testing.T) {
+	ctx, err := ConfigureFromFile("config")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, ctx.Close()) }()
+
+	key, err := ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
+	require.NoError(t, err)
+
+	_, err = ctx.ImportECDSAKeyPairWithLabel(randomBytes(), randomBytes(), key)
+	require.Error(t, err)
+}
+
+// TestImportECDSANilKey rejects a nil key without touching the token.
+func TestImportECDSANilKey(t *testing.T) {
+	ctx, err := ConfigureFromFile("config")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, ctx.Close()) }()
+
+	_, err = ctx.ImportECDSAKeyPair(randomBytes(), nil)
+	require.Error(t, err)
+}


### PR DESCRIPTION
#### Proposed Changes ####

It's currently possible to generate ECDSA key pairs and import certificates, but there is no way to import existing private key material. This change mirrors the `ImportCertificateWithAttributes` / `GenerateECDSAKeyPairWithAttributes` pattern: build the public/private templates from the supplied `*ecdsa.PrivateKey` (`EC_PARAMS`, `EC_POINT`, the private scalar) and `CreateObject` both, rolling back the orphaned public key if the private `CreateObject` fails.

Returns the usual `Signer` so the imported key flows through the existing `Sign`/`Delete` paths.

#### Types of Changes ####

New Feature

#### Verification ####

The new tests create keys outside the HSM, import them, and then sign a message. The signature is then verified against the key (this includes a lookup of the key).

#### Testing ####

Test cases included for importing P-256, P-384, and P-521 keys. P-224 keys are also tested but as a negative test—the `ecdh` library can't use these keys so this test case verifies rejecting the key.

Tests have been run against SoftHSM and the Utimaco HSM simulator. (I may be able to also test against CloudHSM, but this will take a few days.)

#### Linked Issues ####

#### User-Facing Change ####

```release-note
Adds the ability to import existing ECDSA keys which were not created directly on the HSM, similar to the existing ability to import certificates.
```

#### Further Comments ####

Background: I've been porting a Python tool which needs to be able to import raw P-256 keys. I wasn't keen on the idea of opening a `miekg/pkcs11` session directly and reaching round the `crypto11` library as I was concerned that this could lead to all sorts of complexities. Adding the functionality at this layer seemed both reasonable and cleaner.
