### PR TITLE
downgrade the go version to 1.25.0 and add go toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ Installation
 
 Since v1.0.0, crypto11 requires Go v1.11+. Install the library by running:
 
+> **Note on Go version policy**
+>
+> crypto11 is a library. Bumping the `go` directive in `go.mod` raises the **minimum** Go version required by every project that imports it, which can break consumers still on older toolchains.
+>
+> To avoid this, we follow a two-directive pattern:
+> - `go X.Y.0` — the **minimum** Go version consumers need (kept conservative).
+> - `toolchain go X.Y.Z` — the **recommended** toolchain used by maintainers (tracks the latest patch release).
+>
+> This lets projects on older Go versions still import crypto11, while maintainers can develop and test with the latest toolchain.
+> See [#137](https://github.com/thales-transfer/crypto11/issues/137) for context.
+
 ```bash
 go get github.com/ThalesGroup/crypto11
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/ThalesGroup/crypto11
 
-go 1.25.8
+go 1.25.0
+
+toolchain go1.25.8
 
 require (
 	github.com/miekg/pkcs11 v1.1.2


### PR DESCRIPTION
indeed crypto11 is a librairy, updating the go version to newest go affect the projects that use crypto11 but are using an alder go version

https://github.com/thales-transfer/crypto11/issues/137

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce ? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
